### PR TITLE
Parse authentication from URLs to download packages

### DIFF
--- a/metaflow_extensions/netflix_ext/config/mfextinit_netflixext.py
+++ b/metaflow_extensions/netflix_ext/config/mfextinit_netflixext.py
@@ -91,6 +91,15 @@ CONDA_PREFERRED_FORMAT = from_conf(
 
 CONDA_DEFAULT_PIP_SOURCE = from_conf("CONDA_DEFAULT_PIP_SOURCE", None)
 
+# Allows you to specify URLs that need to be authenticated (basically Conda or PIP
+# package sources). Metaflow will glean all the information it can from traditional
+# configuration sources (like pip.conf) but this allows you to specify additional URLs
+# for which authentication is required. A dictionary should be passed in (or a JSON
+# version of it in string form).
+# key: hostname that needs authentication
+# value: a tuple/list of username and password
+CONDA_SRCS_AUTH_INFO = from_conf("CONDA_SRCS_AUTH_INFO", {})
+
 CONDA_REMOTE_COMMANDS = ("batch", "kubernetes")
 
 def _validate_remote_latest(name, value):

--- a/metaflow_extensions/netflix_ext/plugins/conda/conda_step_decorator.py
+++ b/metaflow_extensions/netflix_ext/plugins/conda/conda_step_decorator.py
@@ -627,6 +627,7 @@ class CondaStepDecorator(StepDecorator):
                 _,
                 _,
             ) = EnvsResolver.extract_info_from_base(
+                self.conda,
                 self.from_env,
                 self._resolved_non_base_deps,
                 self._resolved_non_base_sources,


### PR DESCRIPTION
This also introduces a new configuration variable METAFLOW_CONDA_SRCS_AUTH_INFO that allows the user to pass more authentication if needed.

Two other small fixes:
  - properly errors out if file is not downloaded correctly
  - allows using <channel>::<package> in environments that are then the base of other environments