### PR TITLE
Fix an issue when building pip-only environments cross platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,7 @@ If you want support for environments containing only pip packages, you will also
 
 ##### Mixed (pip + conda)  package support
 If you want support for environments containing both pip and conda packages, you will also need:
-- `conda-lock>=2.0.0`
-- `lockfile`
+- `conda-lock>=2.1.0`
 
 ##### Support for `.tar.bz2` and `.conda` packages
 If you set `CONDA_PREFERRED_FORMAT` to either `.tar.bz2` or `.conda`, for some packages,
@@ -167,6 +166,9 @@ constantly improved and there are a few outstanding issues that we are aware of:
   transmutes due to https://github.com/mamba-org/mamba/issues/2328. It also does
   not work properly when transmuting from `.conda` packages to `.tar.bz2` packages.
   Install `conda-package-handling` as well to support this.
+- Newer mamba has issues with newer conda. Specifically, removing environments will cause
+  an error. The fix is out but has not been released yet:
+  https://github.com/mamba-org/mamba/commit/ff161149251a79c86f65f6977a2c2e84f3aea08b
 
 ### Uninstallation
 Uninstalling this package will revert the behavior of the conda decorator to the one

--- a/metaflow_extensions/netflix_ext/cmd/environment/environment_cmd.py
+++ b/metaflow_extensions/netflix_ext/cmd/environment/environment_cmd.py
@@ -924,8 +924,8 @@ def _parse_req_file(
                     parsed_req = Requirement(line)
                 except InvalidRequirement as ex:
                     raise InvalidEnvironmentException(
-                        "Could not parse '%s': %s" % (line, ex)
-                    )
+                        "Could not parse '%s'" % line
+                    ) from ex
                 if parsed_req.marker is not None:
                     raise InvalidEnvironmentException(
                         "Environment markers are not supported for '%s'" % line

--- a/metaflow_extensions/netflix_ext/plugins/conda/conda_step_decorator.py
+++ b/metaflow_extensions/netflix_ext/plugins/conda/conda_step_decorator.py
@@ -160,6 +160,16 @@ class CondaStepDecorator(StepDecorator):
             "Requested for step %s: deps: %s; sources: %s"
             % (self._step_name, str(self.step_deps), str(self.source_deps))
         )
+        if self.is_fetch_at_exec():
+            from_env = self.from_env
+            assert from_env
+            return [
+                EnvID(
+                    req_id=from_env.env_id.req_id,
+                    full_id=from_env.env_id.full_id,
+                    arch=self._arch,
+                )
+            ]
         return [
             EnvID(
                 req_id=ResolvedEnvironment.get_req_id(
@@ -421,6 +431,7 @@ class CondaStepDecorator(StepDecorator):
         if self.is_enabled() and self.is_fetch_at_exec():
             self._flow = flow
             self._env_for_fetch["METAFLOW_RUN_ID"] = run_id
+            self._env_for_fetch["METAFLOW_RUN_ID_BASE"] = run_id
             self._env_for_fetch["METAFLOW_STEP_NAME"] = self.name
 
     def runtime_task_created(


### PR DESCRIPTION
The issue could happen in some conditions and an incorrect environment was built.

Also fix:
  - less verbose exceptions (they were repetitive)
  - more verbose reporting when pip fails so the user can better identify issue
  - better error message when no storage backend is defined