### PR TITLE
deduplicate conda deps to avoid toml errors

### DIFF
--- a/metaflow_extensions/netflix_ext/plugins/conda/resolvers/conda_lock_resolver.py
+++ b/metaflow_extensions/netflix_ext/plugins/conda/resolvers/conda_lock_resolver.py
@@ -188,7 +188,9 @@ class CondaLockResolver(Resolver):
 
             # Add deps
             toml_lines.append("[tool.conda-lock.dependencies]\n")
-            for d in conda_deps:
+
+            # We make the conda_deps a set because toml doesn't tolerate duplicates
+            for d in set(conda_deps):
                 splits = d.split("==", 1)
                 if len(splits) == 2:
                     toml_lines.append('"%s" = "%s"\n' % (splits[0], splits[1]))


### PR DESCRIPTION
If I create a conda environment with pip dependencies embedded without specifying a pip conda package, conda/mamba will try and make me feel bad:

env.yaml
```
name: feelsbadman
channels:
  - conda-forge
dependencies:
  - python==3.12.0
  - pip:
    - click
```

```
$ mamba env create -f env.yaml --dry-run
Retrieving notices: ...working... done
Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies.  Conda may not use the correct pip to install your packages, and they may end up in the wrong place.  Please add an explicit pip dependency.  I'm adding one for you, but still nagging you.

...
```

Trying to be a good person and adding pip as a package dependency like so will make conda less naggy:

```
name: feelsbadman
channels:
  - conda-forge
dependencies:
  - python==3.12.0
  - pip
  - pip:
    - click
```

Unfortunately using the above file in nflx extensions causes things to explode in a rather confusing way:

```
$  metaflow environment resolve -f env.yml  --arch linux-64
```

```
Traceback (most recent call last):
  File "/Users/tylerpotts/miniforge3/envs/x2/bin/conda-lock", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/tylerpotts/miniforge3/envs/x2/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tylerpotts/miniforge3/envs/x2/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/tylerpotts/miniforge3/envs/x2/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tylerpotts/miniforge3/envs/x2/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tylerpotts/miniforge3/envs/x2/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tylerpotts/miniforge3/envs/x2/lib/python3.12/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tylerpotts/miniforge3/envs/x2/lib/python3.12/site-packages/conda_lock/conda_lock.py", line 1320, in lock
    lock_func(
  File "/Users/tylerpotts/miniforge3/envs/x2/lib/python3.12/site-packages/conda_lock/conda_lock.py", line 1033, in run_lock
    make_lock_files(
  File "/Users/tylerpotts/miniforge3/envs/x2/lib/python3.12/site-packages/conda_lock/conda_lock.py", line 327, in make_lock_files
    lock_spec = make_lock_spec(
                ^^^^^^^^^^^^^^^
  File "/Users/tylerpotts/miniforge3/envs/x2/lib/python3.12/site-packages/conda_lock/src_parser/__init__.py", line 89, in make_lock_spec
    lock_specs = _parse_source_files(src_files, platforms)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tylerpotts/miniforge3/envs/x2/lib/python3.12/site-packages/conda_lock/src_parser/__init__.py", line 68, in _parse_source_files
    desired_envs.append(parse_pyproject_toml(src_file, platforms))
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tylerpotts/miniforge3/envs/x2/lib/python3.12/site-packages/conda_lock/src_parser/pyproject_toml.py", line 545, in parse_pyproject_toml
    contents = toml_load(fp)
               ^^^^^^^^^^^^^
  File "/Users/tylerpotts/miniforge3/envs/x2/lib/python3.12/tomllib/_parser.py", line 66, in load
    return loads(s, parse_float=parse_float)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tylerpotts/miniforge3/envs/x2/lib/python3.12/tomllib/_parser.py", line 102, in loads
    pos = key_value_rule(src, pos, out, header, parse_float)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tylerpotts/miniforge3/envs/x2/lib/python3.12/tomllib/_parser.py", line 349, in key_value_rule
    raise suffixed_err(src, pos, "Cannot overwrite a value")
tomllib.TOMLDecodeError: Cannot overwrite a value (at line 13, column 12)
```

Turns out that pip is being counted twice when generating the pyproject.toml [here](https://github.com/Netflix/metaflow-nflx-extensions/blob/main/metaflow_extensions/netflix_ext/plugins/conda/resolvers/conda_lock_resolver.py#L191). This results in the below toml file:

pyproject.toml
```
[build-system]
requires = ["poetry>=0.12"]
build-backend = "poetry.masonry.api"

[tool.conda-lock]
channels = ['conda-forge']
allow-pypi-requests = false

[tool.conda-lock.dependencies]
click = "*"
requests = ">=2.21.0"
numpy = "*"
pip = "*"
python = "3.12.0"
pip = "*"
```

Toml really doesn't like duplicates apparently, so it throws the above error. This can be verified by trying to read in this file like so:


```python
from tomllib import load
from pathlib import Path

p = Path("pyroject.toml")

with p.open("rb") as fp:
    many_tears = toml_load(fp)
```

The simple solution is to cast the python dependency list as a set before adding them to the toml lines.