### PR TITLE
Always install micromamba if needed to create an environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The useful configuration values are listed below:
   typically faster. `micromamba` is sometimes a bit more unstable but can be even faster
 - `CONDA_PYPI_DEPENDENCY_RESOLVER`: `pip` or None; if None, you will not be able to resolve
   environments specifying only pypi dependencies.
-- `CONDA_MIXED_DEPENDENCY_RESOLVER`:  `conda-lock` or None; if None, you will not be able
+- `CONDA_MIXED_DEPENDENCY_RESOLVER`:  `conda-lock` or `none`; if `none`, you will not be able
   to resolve environments specifying a mix of pypi and conda dependencies.
 - `CONDA_REMOTE_INSTALLER_DIRNAME`: if set contains a prefix within
   `CONDA_S3ROOT`/`CONDA_AZUREROOT`/`CONDA_GSROOT`
@@ -99,7 +99,8 @@ The useful configuration values are listed below:
   (defaults to `envs`)
 - `CONDA_LOCAL_DIST`: if set architecture specific tar ball in `CONDA_LOCAL_DIST_DIRNAME`.
 - `CONDA_LOCAL_PATH`: if set, installs the tarball in `CONDA_LOCAL_DIST` in this path.
-- `CONDA_PREFERRED_FORMAT`: `.tar.bz2` or `.conda`. Prefer `.conda` for speed gains; any
+- `CONDA_PREFERRED_FORMAT`: `.tar.bz2` or `.conda` or `none` (default).
+  Prefer `.conda` for speed gains; any
   package not available in the preferred format will be transmuted to it automatically.
   If left empty, whatever package is found will be used (ie: there is no preference)
 - `CONDA_DEFAULT_PYPI_SOURCE`: mirror to use for PYPI.

--- a/docs/conda.md
+++ b/docs/conda.md
@@ -125,8 +125,8 @@ file (all configuration options are given
 This section lists some useful configuration options
 
 ### Resolvers
-By default, this extension will not resolve mixed pypi and conda packages. To do so, you need to set
-`METAFLOW_CONDA_MIXED_DEPENDENCY_RESOLVER` to `conda-lock`.
+By default, this extension will resolve mixed pypi and conda packages. To disable this,
+you need to set `METAFLOW_CONDA_MIXED_DEPENDENCY_RESOLVER` to `none` (the string).
 
 We also use `mamba` by default to resolve environments. You can change this to `micromamba` or
 `conda` using `METAFLOW_CONDA_DEPENDENCY_RESOLVER`.

--- a/metaflow_extensions/netflix_ext/config/mfextinit_netflixext.py
+++ b/metaflow_extensions/netflix_ext/config/mfextinit_netflixext.py
@@ -43,16 +43,18 @@ CONDA_DEPENDENCY_RESOLVER = from_conf(
     get_validate_choice_fn(["mamba", "conda", "micromamba"]),
 )
 
-# For pure PYPI environments, if you want to support those, set to the pypi resolver
+# For pure PYPI environments, if you want to support those, set to the pypi resolver.
+# Set to "none" if you do not want to support this functionality.
 CONDA_PYPI_DEPENDENCY_RESOLVER = from_conf(
-    "CONDA_PYPI_DEPENDENCY_RESOLVER", "pip", get_validate_choice_fn(["pip"])
+    "CONDA_PYPI_DEPENDENCY_RESOLVER", "pip", get_validate_choice_fn(["pip", "none"])
 )
 
 # For mixed conda/pypi environments, if you want to support those, set this to 'conda-lock'
+# Set to "none" if you want to disable this functionality.
 CONDA_MIXED_DEPENDENCY_RESOLVER = from_conf(
     "CONDA_MIXED_DEPENDENCY_RESOLVER",
-    None,
-    get_validate_choice_fn(["conda-lock"]),
+    "conda-lock",
+    get_validate_choice_fn(["conda-lock", "none"]),
 )
 
 # Timeout trying to acquire the lock to create environments
@@ -93,8 +95,8 @@ CONDA_LOCAL_PATH = from_conf("CONDA_LOCAL_PATH")
 # Preferred Format for Conda packages
 CONDA_PREFERRED_FORMAT = from_conf(
     "CONDA_PREFERRED_FORMAT",
-    None,
-    get_validate_choice_fn([".tar.bz2", ".conda"]),
+    "none",
+    get_validate_choice_fn([".tar.bz2", ".conda", "none"]),
 )
 
 CONDA_DEFAULT_PYPI_SOURCE = from_conf("CONDA_DEFAULT_PYPI_SOURCE", None)

--- a/metaflow_extensions/netflix_ext/plugins/conda/conda_environment.py
+++ b/metaflow_extensions/netflix_ext/plugins/conda/conda_environment.py
@@ -207,7 +207,7 @@ class CondaEnvironment(MetaflowEnvironment):
                 # NOTE: Assumes here that remote nodes are Linux
                 "if [[ -n $(printenv LD_LIBRARY_PATH) ]]; then "
                 "export MF_ORIG_LD_LIBRARY_PATH=$(printenv LD_LIBRARY_PATH); "
-                "export LD_LIBRARY_PATH=$(cat _lib_path):$(printenv LD_LIBRARY_PATH); fi",
+                "export LD_LIBRARY_PATH=$(cat _env_path)/lib:$(printenv LD_LIBRARY_PATH); fi",
                 "echo 'Environment bootstrapped.'",
                 "export CONDA_END=$(date +%s)",
             ]

--- a/metaflow_extensions/netflix_ext/plugins/conda/envsresolver.py
+++ b/metaflow_extensions/netflix_ext/plugins/conda/envsresolver.py
@@ -178,7 +178,7 @@ class EnvsResolver(object):
                 "sources": user_sources,
                 "extras": extras,
                 "conda_format": [CONDA_PREFERRED_FORMAT]
-                if CONDA_PREFERRED_FORMAT
+                if CONDA_PREFERRED_FORMAT and CONDA_PREFERRED_FORMAT != "none"
                 else ["_any"],
                 "base": base_env,
                 "base_accurate": base_env
@@ -909,7 +909,7 @@ class EnvsResolver(object):
             resolver_name = CONDA_MIXED_DEPENDENCY_RESOLVER
         else:
             raise CondaException("Unhandled environment type %s" % env_type.value)
-        if resolver_name is None:
+        if resolver_name is None or resolver_name == "none":
             raise CondaException(
                 "Cannot resolve environments in %s mode because no resolver is configured"
                 % env_type.value

--- a/metaflow_extensions/netflix_ext/plugins/conda/remote_bootstrap.py
+++ b/metaflow_extensions/netflix_ext/plugins/conda/remote_bootstrap.py
@@ -75,11 +75,11 @@ def bootstrap_environment(
     with open("_env_id", mode="w", encoding="utf-8") as f:
         json.dump(EnvID(req_id, full_id, arch_id()), f)
 
-    # Same thing for lib path
-    with open("_lib_path", mode="w", encoding="utf-8") as f:
+    # Same thing for env path (used to set lib for example)
+    with open("_env_path", mode="w", encoding="utf-8") as f:
         if python_bin is None:
             raise RuntimeError("Environment was not created properly")
-        json.dump(os.path.join(os.path.dirname(os.path.dirname(python_bin)), "lib"), f)
+        json.dump(os.path.dirname(os.path.dirname(python_bin)), f)
 
 
 def setup_conda_manifest():

--- a/metaflow_extensions/netflix_ext/plugins/conda/utils.py
+++ b/metaflow_extensions/netflix_ext/plugins/conda/utils.py
@@ -79,7 +79,7 @@ class AliasType(Enum):
 # List of formats that guarantees the preferred format is first. This is important as
 # functions that rely on selecting the "preferred" source of a package rely on the
 # preferred format being first.
-if CONDA_PREFERRED_FORMAT:
+if CONDA_PREFERRED_FORMAT and CONDA_PREFERRED_FORMAT != "none":
     CONDA_FORMATS = (
         CONDA_PREFERRED_FORMAT,
         *[x for x in _ALL_CONDA_FORMATS if x != CONDA_PREFERRED_FORMAT],

--- a/metaflow_extensions/netflix_ext/plugins/environment_cli.py
+++ b/metaflow_extensions/netflix_ext/plugins/environment_cli.py
@@ -286,6 +286,7 @@ def show(obj: Any, local_only: bool, steps_to_show: Tuple[str]):
                         {
                             "conda": [CONDA_PREFERRED_FORMAT]
                             if CONDA_PREFERRED_FORMAT
+                            and CONDA_PREFERRED_FORMAT != "none"
                             else ["_any"]
                         }
                     ):


### PR DESCRIPTION
There is a bug in mamba/conda so if we need to create an environment, we now ensure that micromamba is installed and install it if it isn't.

Other small changes:
  - defaults to having MIXED mode enabled by default