### PR TITLE
Support pip-repositories in conda-lock 2.4.0+

### DIFF
--- a/metaflow_extensions/netflix_ext/cmd/environment/environment_cmd.py
+++ b/metaflow_extensions/netflix_ext/cmd/environment/environment_cmd.py
@@ -55,7 +55,7 @@ from .utils import download_mf_version
 
 
 REQ_SPLIT_LINE = re.compile(r"([^~<=>]*)([~<=>]+.*)?")
-YML_SPLIT_LINE = re.compile(r"(<|>|<=|>=|=>|=<|~=|=)")
+YML_SPLIT_LINE = re.compile(r"(<=|>=|=>|=<|~=|==|<|>|=)")
 
 
 class CommandObj:
@@ -1024,7 +1024,7 @@ def _parse_yml_file(
                             to_update[line] = ""
                     else:
                         dep_name, dep_operator, dep_version = splits
-                        if dep_operator != "=":
+                        if dep_operator not in ("=", "=="):
                             dep_version = dep_operator + dep_version
                         if dep_name == "python":
                             if dep_version:

--- a/metaflow_extensions/netflix_ext/plugins/conda/conda.py
+++ b/metaflow_extensions/netflix_ext/plugins/conda/conda.py
@@ -1946,9 +1946,9 @@ class Conda(object):
                 .decode("utf-8")
                 .split()[-1]
             )
-            if parse_version(conda_lock_version) < parse_version("2.0.0"):
+            if parse_version(conda_lock_version) < parse_version("2.4.0"):
                 self.echo(
-                    "conda-lock is installed but not recent enough (2.0.0 or later "
+                    "conda-lock is installed but not recent enough (2.4.0 or later "
                     "is required) --ignoring"
                 )
                 del self._bins["conda-lock"]


### PR DESCRIPTION
This PR migrates support from our very hacky way of injecting repositories to the supported one. It now requires conda-lock 2.4.0+ if mixed mode is used.