### PR TITLE
Various fixes from upstream:

### DIFF
--- a/metaflow_extensions/netflix_ext/cmd/environment/environment_cmd.py
+++ b/metaflow_extensions/netflix_ext/cmd/environment/environment_cmd.py
@@ -326,6 +326,10 @@ def create(
         resolver = EnvsResolver(obj.conda)
         # We force the env_type to be the same as the base env since we don't modify that
         # by adding these deps.
+
+        # We also force the use of use_latest because we are not really doing anything
+        # that would require a re-resolve (ie: the user doesn't really care about the
+        # version of ipykernel most likely).
         resolver.add_environment(
             arch_id(),
             user_deps={
@@ -334,6 +338,8 @@ def create(
             user_sources={},
             extras={},
             base_env=env,
+            local_only=local_only,
+            use_latest=":any:",
         )
         resolver.resolve_environments(obj.echo)
         update_envs = []  # type: List[ResolvedEnvironment]
@@ -1007,6 +1013,8 @@ def _parse_req_file(
                 extra_args.setdefault("pypi", []).append(" ".join([first_word, rem]))
             elif first_word in ("--pre", "--no-index"):
                 extra_args.setdefault("pypi", []).append(first_word)
+            elif first_word == "--conda-channel" and rem:
+                sources.setdefault("conda", []).append(rem)
             elif first_word == "--conda-pkg":
                 # Special extension to allow non-python conda package specification
                 split_res = REQ_SPLIT_LINE.match(splits[1])

--- a/metaflow_extensions/netflix_ext/config/mfextinit_netflixext.py
+++ b/metaflow_extensions/netflix_ext/config/mfextinit_netflixext.py
@@ -15,9 +15,11 @@ CONDA_S3ROOT = from_conf(
 
 CONDA_AZUREROOT = from_conf(
     "CONDA_AZUREROOT",
-    os.path.join(DATASTORE_SYSROOT_AZURE, "conda_env")
-    if DATASTORE_SYSROOT_AZURE
-    else None,
+    (
+        os.path.join(DATASTORE_SYSROOT_AZURE, "conda_env")
+        if DATASTORE_SYSROOT_AZURE
+        else None
+    ),
 )
 
 CONDA_GSROOT = from_conf(
@@ -27,9 +29,11 @@ CONDA_GSROOT = from_conf(
 
 CONDA_LOCALROOT = from_conf(
     "CONDA_LOCALROOT",
-    os.path.join(DATASTORE_SYSROOT_LOCAL, "conda_env")
-    if DATASTORE_SYSROOT_LOCAL
-    else None,
+    (
+        os.path.join(DATASTORE_SYSROOT_LOCAL, "conda_env")
+        if DATASTORE_SYSROOT_LOCAL
+        else None
+    ),
 )
 
 CONDA_MAGIC_FILE_V2 = "conda_v2.cnd"
@@ -132,9 +136,18 @@ CONDA_SYS_DEFAULT_PACKAGES = from_conf(
 # Packages to add when building for GPU machines (ie: if there is a GPU resource
 # requirement). As an example you can set this to:
 # CONDA_SYS_DEFAULT_GPU_PACKAGES = {
-#     "__cuda": os.environ.get("CONDA_OVERRIDE_CUDA", "11.8")
+#     "__cuda": os.environ.get("CONDA_OVERRIDE_CUDA", "11.8=0")
 # }
 CONDA_SYS_DEFAULT_GPU_PACKAGES = {}
+
+# Packages that are needed when creating an intermediate conda environment to resolve
+# a pypi environment. This can be used to add packages needed for authentication for
+# example.
+builder_packages = []
+if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
+    builder_packages = ["keyrings.google-artifactregistry-auth"]
+
+CONDA_BUILDER_ENV_PACKAGES = from_conf("CONDA_BUILDER_ENV_PACKAGES", builder_packages)
 
 
 def _validate_remote_latest(name, value):

--- a/metaflow_extensions/netflix_ext/plugins/conda/conda_step_decorator.py
+++ b/metaflow_extensions/netflix_ext/plugins/conda/conda_step_decorator.py
@@ -292,7 +292,6 @@ class SysPackagesRequirementStepDecorator(
 
 # Here for legacy reason -- use @pypi instead
 class PipRequirementStepDecorator(PypiRequirementStepDecorator):
-    name = "pip"
     """
     Specifies the Pypi packages for the step.
 
@@ -331,6 +330,8 @@ class PipRequirementStepDecorator(PypiRequirementStepDecorator):
     disabled : bool, default False
         If set to True, uses the external environment.
     """
+
+    name = "pip"
 
     def step_init(
         self,

--- a/metaflow_extensions/netflix_ext/plugins/conda/env_descr.py
+++ b/metaflow_extensions/netflix_ext/plugins/conda/env_descr.py
@@ -1403,5 +1403,9 @@ def write_to_conda_manifest(ds_root: str, info: CachedEnvironmentInfo):
             f.truncate(0)
             current_content.update(info)
             json.dump(current_content.to_dict(), f)
+
+            # Flush data from python file object to OS buffer and eventually to disk.
+            f.flush()
+            os.fsync(f.fileno())
         finally:
             fcntl.flock(f, fcntl.LOCK_UN)

--- a/metaflow_extensions/netflix_ext/plugins/conda/envsresolver.py
+++ b/metaflow_extensions/netflix_ext/plugins/conda/envsresolver.py
@@ -27,6 +27,7 @@ from metaflow.metaflow_config import (
     CONDA_PYPI_DEPENDENCY_RESOLVER,
     CONDA_SYS_DEPENDENCIES,
     CONDA_SYS_DEFAULT_PACKAGES,
+    CONDA_USE_REMOTE_LATEST,
 )
 from metaflow.metaflow_environment import InvalidEnvironmentException
 
@@ -84,6 +85,7 @@ class EnvsResolver(object):
         base_env: Optional[ResolvedEnvironment] = None,
         base_from_full_id: bool = False,
         local_only: bool = False,
+        use_latest: str = CONDA_USE_REMOTE_LATEST,
         force: bool = False,
         force_co_resolve: bool = False,
     ):
@@ -115,6 +117,11 @@ class EnvsResolver(object):
         local_only : bool, optional
             True if we should only look for resolved environments locally and not
             remotely, by default False
+        use_latest : str, default METAFLOW_CONDA_USE_REMOTE_LATEST
+            For default environments, determine if we allow fetching the latest environment
+            remotely resolved. If ":none:", we don't fetch anything. If ":username:", we
+            fetch the latest environment resolved by the current user. If ":any:", we fetch
+            the latest environment resolved by any user.
         force : bool, optional
             True if we should force resolution even if this environment is known,
             by default False
@@ -155,7 +162,9 @@ class EnvsResolver(object):
             resolved_env = base_env
         else:
             resolved_env = (
-                self._conda.environment(env_id, local_only) if not force else None
+                self._conda.environment(env_id, local_only, use_latest)
+                if not force
+                else None
             )
 
         # Check if we have already requested this environment

--- a/metaflow_extensions/netflix_ext/plugins/conda/resolvers/conda_lock_resolver.py
+++ b/metaflow_extensions/netflix_ext/plugins/conda/resolvers/conda_lock_resolver.py
@@ -227,7 +227,7 @@ class CondaLockResolver(Resolver):
                 if arch_id() == architecture or sys_overrides:
                     lines = ["subdirs:\n", "  %s:\n" % architecture, "    packages:\n"]
                     lines.extend(
-                        "      %s: %s\n" % (virt_pkg, virt_build_str)
+                        '      %s: "%s"\n' % (virt_pkg, virt_build_str)
                         for virt_pkg, virt_build_str in self._conda.virtual_packages.items()
                         if virt_pkg not in sys_overrides
                     )


### PR DESCRIPTION
  - properly handle sys packages when cross building
  - add --conda-channel to requirements.txt type of files
  - fix issue when locally building a package that already had a local identifier
  - better handling of determining if a newer package needs to be built when pointing to a local directory or file
  - add support to specify additional packages for builder environments thereby supporting authentication using GOOGLE_APPLICATION_CREDENTIALS
  - improved support for python 3.7
  - more efficient environment building when building an environment that just adds ipykernel
  - fix issue with micromamba in some cases (it would "hang" when compiling .pyc files)