### PR TITLE
Add extensions to debug flows in isolated notebook instance

### DIFF
--- a/metaflow_extensions/netflix_ext/cmd/debug/constants.py
+++ b/metaflow_extensions/netflix_ext/cmd/debug/constants.py
@@ -1,0 +1,328 @@
+import os
+from .jupyter_instructions_markdown import _jupyter_instructions_markdown
+from .jupyter_title_markdown import _jupyter_title_markdown
+
+
+class Constants(object):
+    # Default Python version
+    DEFAULT_PYTHON_VERSION = "3.7"
+
+    # Stubbed class for Metaflow artifacts
+    DEBUG_INPUT_ITEM_STUB = """
+    class DebugInputItem({FlowSpecClass}):
+        def __init__(self, task):
+            self._task = task
+            if self.has_index():
+                self._index = task.index
+            self._artifact_data = {{}}
+    
+        def has_index(self):
+            return hasattr(self._task, "index")
+        
+        def __repr__(self):
+            return self._task.__repr__()
+    
+        @property
+        def index(self):
+            if self.has_index():
+                return self._index
+            else:
+                raise AttributeError("Task does not have an 'index' attribute")
+    
+        def __getattr__(self, name):
+            if name in self.__dict__:
+                return self.__dict__[name]
+            
+            if name in self._artifact_data:
+                return self._artifact_data[name]
+            
+            try:
+                result = self._task[name]
+            except KeyError:
+                raise AttributeError(f"No such attribute: {{name}}")
+            
+            result = result.data
+            self._artifact_data[name] = result
+            return result
+    """
+
+    # Stubbed class for inputs in Metaflow
+    DEBUG_INPUT_STUB = """
+    class DebugInput({FlowSpecClass}):
+        def __init__(self, inputs, previous_steps, join_type):
+            self._inputs = inputs
+            self._previous_steps = previous_steps
+            if join_type == "static":
+                self._set_input_attributes()
+        
+        def _set_input_attributes(self):
+            for i, step in enumerate(self._previous_steps):
+                setattr(self, step.id, self._inputs[i])
+        
+        def __getitem__(self, idx):
+            return self._inputs[idx]
+        
+        def __iter__(self):
+            return iter(self._inputs)        
+    """
+
+    # Stubbed class for linear steps in Metaflow
+    DEBUG_LINEAR_STEP_STUB = """
+    class DebugLinearStep({FlowSpecClass}):
+        def __init__(self, task, prev_task, step_name):
+            self._cur_task = task
+            self._prev_task = prev_task
+            self._current_step = step_name
+            if self.has_index():
+                self._index = self._cur_task.index    
+            self._artifact_data = {{}}
+    
+        def has_index(self):
+            return hasattr(self._cur_task, "index")
+    
+        @property
+        def index(self):
+            if self.has_index():
+                return self._index
+            else:
+                raise AttributeError("Task does not have an 'index' attribute")
+        
+        def __getattribute__(self, name):
+            # If attribute is of type Parameter in the base class, use __getattr__ instead
+            if isinstance({FlowSpecClass}.__dict__.get(name, None), Parameter):
+                return object.__getattribute__(self, '__getattr__')(name)
+            return super().__getattribute__(name)
+    
+        @property
+        def input(self):
+            if self.has_index():
+                self._input_name = self._cur_task["_foreach_stack"].data[-1].var
+                return self._prev_task[self._input_name].data[self._index]
+            else:
+                raise AttributeError("Task does not have any inputs")
+    
+        def __getattr__(self, name):
+            if name in self.__dict__:
+                return self.__dict__[name]
+            
+            if name in self._artifact_data:
+                return self._artifact_data[name]
+            
+            self.load_artifact_data(name)
+    
+            if name in self._artifact_data:
+                return self._artifact_data[name]
+            
+            raise AttributeError(f"No such attribute: {{name}}")
+    
+        def load_artifact_data(self, name):
+            for artifact in self._prev_task.artifacts:
+                if artifact.id == name:
+                    self._artifact_data[name] = artifact.data    
+    """
+
+    # Stubbed class for join step in Metaflow
+    DEBUG_JOIN_STEP_STUB = """
+    class DebugJoinStep({FlowSpecClass}):
+        def __init__(self, _task, prev_tasks, inputs, step_name, node):
+            self._task = _task
+            self._prev_tasks = prev_tasks
+            self._inputs = inputs
+            self._current_step = step_name
+            self.node = node
+            if self.has_index():
+                self._index = _task.index
+            self._to_merge = {{}}
+    
+        def has_index(self):
+            return hasattr(self._task, "index")
+    
+        @property
+        def index(self):
+            if self.has_index():
+                return self._index
+            else:
+                raise AttributeError("Task does not have an 'index' attribute")    
+        
+        def __getattribute__(self, name):
+            # If attribute is of type Parameter in the base class, use __getattr__ instead
+            if isinstance({FlowSpecClass}.__dict__.get(name, None), Parameter):
+                return object.__getattribute__(self, '__getattr__')(name)
+            return super().__getattribute__(name)
+    
+        def __getattr__(self, name):
+            if name in self.__dict__:
+                return self.__dict__[name]
+            
+            if name in self._to_merge:
+                inp, _ = self._to_merge[name]
+                setattr(self, name, inp.__getattr__(name))
+                return self.__dict__[name]
+            
+            raise AttributeError(f"No such attribute: {{name}}")
+
+        def merge_artifacts(
+            self,
+            inputs,
+            exclude=None,
+            include=None,
+        ) -> None:
+            # Most of the code has been taken as is from OSS Metaflow
+            # NOTE: Keep this function in sync with the OSS code
+            include = include or []
+            exclude = exclude or []
+            if self.node["type"] != "join":
+                msg = (
+                    "merge_artifacts can only be called in a join and step *{{step}}* "
+                    "is not a join".format(step=self._current_step)
+                )
+                raise MetaflowException(msg)
+            if len(exclude) > 0 and len(include) > 0:
+                msg = "`exclude` and `include` are mutually exclusive in merge_artifacts"
+                raise MetaflowException(msg)
+    
+            to_merge = {{}}
+            unresolved = []
+            for inp in inputs:
+                # available_vars is the list of variables from inp that should be considered
+                if include:
+                    available_vars = (
+                        (var.id, var.sha)
+                        for var in inp._task.artifacts
+                        if (var.id in include) and (not hasattr(self, var.id))
+                    )
+                else:
+                    available_vars = (
+                        (var.id, var.sha)
+                        for var in inp._task.artifacts
+                        if (var.id not in exclude) and (not hasattr(self, var.id))
+                    )
+                for var, sha in available_vars:
+                    _, previous_sha = to_merge.setdefault(var, (inp, sha))
+                    if previous_sha != sha:
+                        # We have a conflict here
+                        unresolved.append(var)
+            # Check if everything in include is present in to_merge
+            missing = []
+            for v in include:
+                if v not in to_merge and not hasattr(self, v):
+                    missing.append(v)
+            if unresolved:
+                # We have unresolved conflicts, so we do not set anything and error out
+                msg = (
+                    "Step *{{step}}* cannot merge the following artifacts due to them "
+                    "having conflicting values: [{{artifacts}}]. To remedy this issue, "
+                    "be sure to explicitly set those artifacts (using "
+                    "self.<artifact_name> = ...) prior to calling merge_artifacts.".format(
+                        step=self._current_step, artifacts=", ".join(unresolved)
+                    )
+                )
+                raise UnhandledInMergeArtifactsException(msg, unresolved)
+            if missing:
+                msg = (
+                    "Step *{{step}}* specifies that [{{include}}] should be merged but "
+                    "[{{missing}}] are not present. To remedy this issue, make sure "
+                    "that the values specified in only come from at least one branch".format(
+                        step=self._current_step,
+                        include=", ".join(include),
+                        missing=", ".join(missing),
+                    )
+                )
+                raise MissingInMergeArtifactsException(msg, missing)
+            # If things are resolved, we pass down the variables from the input datastore
+            self._to_merge = to_merge        
+
+    """
+
+    # Escape hatch stub
+    ESCAPE_HATCH_STUB = """
+    import sys
+    sys.path.insert(0, "{MetaflowEnvEscapeDir}")    
+    """
+
+    # Imports needed to define stubbed classes & Debug steps
+    IMPORTS_STUB = """
+    from metaflow.exception import (
+        MetaflowException,
+        UnhandledInMergeArtifactsException,
+        MissingInMergeArtifactsException,
+    )
+    from debug_stub_generator import DebugStubGenerator
+    from current_stub_generator import CurrentStubGenerator
+    from metaflow import Parameter, Task
+    import metaflow.task
+    import importlib
+    
+    module = importlib.import_module("{MetaflowFileName}")
+    for name in dir(module):
+        if not name.startswith("__"): 
+            globals()[name] = getattr(module, name)
+    """
+
+    # Template to instantiate the current stub generator
+    CURRENT_STUB_INSTANTIATION_TEMPLATE = """
+    current = CurrentStubGenerator("{TaskPathspec}")
+    """
+
+    # Template to instantiate the debug stub generator
+    DEBUG_STUB_GENERATOR_INSTANTIATION_TEMPLATE = """
+    debug_stub_generator = DebugStubGenerator("{TaskPathspec}")
+    task = debug_stub_generator.task
+    step_name = debug_stub_generator.step_name
+    node = debug_stub_generator.node
+    previous_steps = debug_stub_generator.previous_steps
+    previous_tasks = debug_stub_generator.previous_tasks    
+    """
+
+    # Template to create instances of stubbed start classes
+    START_STUB_INSTANTIATION_TEMPLATE = """
+    self = DebugLinearStep(task, Task("{ParameterTask}"), step_name)
+    """
+
+    # Template to create instances of stubbed linear classes
+    LINEAR_STUB_INSTANTIATION_TEMPLATE = """
+    self = DebugLinearStep(task, previous_tasks[0], step_name)
+    """
+
+    # Template to create instances of stubbed join classes
+    JOIN_STUB_INSTANTIATION_TEMPLATE = """
+    join_inputs = [DebugInputItem(task) for task in previous_tasks]
+    join_type = debug_stub_generator.get_join_type(previous_steps)
+    inputs = DebugInput(join_inputs, previous_steps, join_type)
+    self = DebugJoinStep(task, previous_tasks, inputs, step_name, node)
+    """
+
+    # Inspect mode means that we return the state of the task after it has finished running
+    # The templates remain the same except that the artifact values are fetched from the current task
+    # instead of the previous task
+
+    # Template to create instances of stubbed start classes for inspection
+    START_STUB_INSPECT_INSTANTIATION_TEMPLATE = """
+    prev_task = Task("{ParameterTask}")
+    self = DebugLinearStep(task, task, step_name)
+    """
+
+    # Template to create instances of stubbed linear classes for inspection
+    LINEAR_STUB_INSPECT_INSTANTIATION_TEMPLATE = """
+    self = DebugLinearStep(task, task, step_name)
+    """
+
+    # Template to create instances of stubbed join classes for inspection
+    JOIN_STUB_INSPECT_INSTANTIATION_TEMPLATE = """
+    join_inputs = [DebugInputItem(task) for task in previous_tasks]
+    join_type = debug_stub_generator.get_join_type(previous_steps)
+    inputs = DebugInput(join_inputs, previous_steps, join_type)
+    self = DebugJoinStep(task, task, inputs, step_name, node)
+    """
+
+    # Template for importing the namespace of the current task
+    CURRENT_TASK_NAMESPACE_STUB = """
+    from metaflow import namespace
+    namespace("{Namespace}")
+    """
+
+    # Template for rendering the instructions in markdown
+    JUPYTER_INSTRUCTIONS_MARKDOWN = _jupyter_instructions_markdown
+
+    # Template for rendering the notebook title in markdown
+    JUPYTER_TITLE_MARKDOWN = _jupyter_title_markdown

--- a/metaflow_extensions/netflix_ext/cmd/debug/current_stub_generator.py
+++ b/metaflow_extensions/netflix_ext/cmd/debug/current_stub_generator.py
@@ -1,0 +1,198 @@
+import os
+
+from typing import Dict, List, Any, Optional
+from metaflow import Task, namespace, Step, Run
+from metaflow.plugins.env_escape import generate_trampolines
+
+
+class CurrentStubGenerator(object):
+    def __init__(self, task_pathspec):
+        """
+        Initializes the CurrentStubGenerator.
+
+        Parameters
+        ----------
+        task_pathspec : str
+            The pathspec of the task.
+        """
+        self._task_pathspec = task_pathspec
+        self._task = Task(task_pathspec, _namespace_check=False)
+        self._step_name = self.task.parent.id
+        self._run_id = self.task.parent.parent.id
+        self._flow_name = self.task.parent.parent.parent.id
+
+    def get(self, key: str, default: Optional[Any] = None) -> Optional[Any]:
+        """
+        Returns the value of the attribute with the given key.
+
+        Parameters
+        ----------
+        key : str
+            The key of the attribute.
+        default : Any, optional, default None
+            The default value to return if the key is not found.
+
+        Returns
+        -------
+        Any
+            The value of the attribute with the given key, or the default value
+            if the key is not found.
+        """
+        return getattr(self, key, default)
+
+    def __getattr__(self, key: str, default: Optional[Any] = None) -> Optional[Any]:
+        """
+        Called when an attribute lookup has not found the attribute in the usual places.
+
+        Parameters
+        ----------
+        key : str
+            The key of the attribute.
+        default : Any, optional, default None
+            The default value to return if the key is not found.
+
+        Raises
+        ------
+        AttributeError
+            If the attribute does not exist.
+        """
+        raise AttributeError(
+            "'{}' object has no attribute '{}'. The Current Stub does not support all the "
+            "Current singleton attributes yet.".format(type(self).__name__, key)
+        )
+
+    def __contains__(self, key: str) -> bool:
+        """
+        Returns True if the attribute with the given key exists, False otherwise.
+
+        Parameters
+        ----------
+        key : str
+            The key of the attribute.
+
+        Returns
+        -------
+        bool
+            True if the attribute with the given key exists, False otherwise.
+        """
+        return getattr(self, key, None) is not None
+
+    @property
+    def is_running_flow(self) -> bool:
+        """
+        Always returns True as this is a stub generator for a running flow.
+
+        Returns
+        -------
+        bool
+            True
+        """
+        return True
+
+    @property
+    def flow_name(self) -> Optional[str]:
+        """
+        The name of the currently executing flow.
+
+        Returns
+        -------
+        str, optional
+            Flow name.
+        """
+        return self._flow_name
+
+    @property
+    def run_id(self) -> Optional[str]:
+        """
+        The run ID of the currently executing run.
+
+        Returns
+        -------
+        str, optional
+            Run ID.
+        """
+        return self._run_id
+
+    @property
+    def step_name(self) -> Optional[str]:
+        """
+        The name of the currently executing step.
+
+        Returns
+        -------
+        str, optional
+            Step name.
+        """
+        return self._step_name
+
+    @property
+    def task_id(self) -> Optional[str]:
+        """
+        The task ID of the currently executing task.
+
+        Returns
+        -------
+        str, optional
+            Task ID.
+        """
+        return self.task.id
+
+    @property
+    def retry_count(self) -> int:
+        """
+        The index of the task execution attempt.
+
+        Returns
+        -------
+        int
+            The index of the task execution attempt.
+        """
+        return int(self._task.metadata_dict.get("attempt", 0))
+
+    @property
+    def origin_run_id(self) -> Optional[str]:
+        """
+        The original run ID of the currently executing run.
+
+        Returns
+        -------
+        str, optional
+            Original run ID.
+        """
+        return str(self._task.metadata_dict.get("origin-run-id", None))
+
+    @property
+    def pathspec(self) -> str:
+        """
+        The pathspec of the currently executing task.
+
+        Returns
+        -------
+        str
+            Pathspec.
+        """
+        return self._task_pathspec
+
+    @property
+    def task(self) -> Task:
+        """
+        The currently executing task.
+
+        Returns
+        -------
+        Task
+            The currently executing task.
+        """
+        return self._task
+
+    @property
+    def run(self) -> Run:
+        """
+        The currently executing run.
+
+        Returns
+        -------
+        Run
+            The currently executing run.
+        """
+        return self.task.parent.parent

--- a/metaflow_extensions/netflix_ext/cmd/debug/debug_cmd.py
+++ b/metaflow_extensions/netflix_ext/cmd/debug/debug_cmd.py
@@ -1,0 +1,266 @@
+import os
+import tarfile
+import datetime
+
+from metaflow import namespace, Task
+from metaflow._vendor import click
+from typing import Any, Dict, Optional, Tuple
+from metaflow.exception import CommandException
+from metaflow.cli import echo_dev_null, echo_always
+from .debug_script_generator import DebugScriptGenerator
+from .debug_utils import (
+    fetch_environment_type,
+    copy_stub_generator_to_metaflow_root_dir,
+    _set_python_environment,
+    _extract_code_package,
+    _find_kernel_name,
+    _generate_escape_trampolines,
+)
+
+
+class CommandObj:
+    def __init__(self):
+        pass
+
+
+@click.group()
+@click.pass_context
+def cli(ctx):
+    pass
+
+
+@cli.group(help="Post/Pre Step debugging commands")
+@click.option(
+    "--quiet/--no-quiet",
+    show_default=True,
+    default=False,
+    help="Suppress unnecessary messages",
+)
+@click.pass_context
+def debug(
+    ctx: Any,
+    quiet: bool,
+):
+    if quiet:
+        echo = echo_dev_null
+    else:
+        echo = echo_always
+
+    obj = CommandObj()
+    obj.quiet = quiet
+    obj.echo = echo
+    obj.echo_always = echo_always
+    ctx.obj = obj
+
+
+@debug.command(hidden=True)
+@click.option(
+    "--task-pathspec",
+    help="Pathspec for the task to generate the escape trampolines for",
+    required=True,
+)
+@click.option(
+    "--metaflow-root-dir",
+    help="Root directory where the escape trampolines should be inserted",
+    required=True,
+)
+@click.option(
+    "--inspect",
+    help="If 'true' or '1', generates script to inspect the state of the task after it has finished running",
+    type=str,
+    default="false",
+)
+@click.option(
+    "--generate-notebook",
+    help="If 'true' or '1', setup a notebook with debugging params",
+    type=str,
+    default="true",
+)
+@click.option(
+    "--python-executable",
+    help="The python executable path for the debug task",
+    required=False,
+    default=None,
+)
+@click.pass_obj
+def generate_debug_scripts(
+    obj,
+    task_pathspec: str,
+    metaflow_root_dir: str,
+    inspect: str,
+    generate_notebook: str,
+    python_executable: Optional[str] = None,
+):
+    """
+    Generates the debug scripts for the task.
+    """
+    # Move logic to _generate_debug_scripts to make it reusable
+    _generate_debug_scripts(
+        obj,
+        task_pathspec,
+        metaflow_root_dir,
+        inspect,
+        generate_notebook,
+        python_executable,
+    )
+
+
+@debug.command()
+@click.option(
+    "--metaflow-root-dir",
+    help="Root directory where the code package and debug scripts/notebooks should be generated",
+    required=True,
+)
+@click.option(
+    "--override-env",
+    help="Name of the named environment to use for debugging the task. Overrides the Conda environment from this task",
+)
+@click.option(
+    "--override-env-from-pathspec",
+    help="Pathspec to use as environment for debugging the task. Overrides the Conda environment from this task",
+)
+@click.option(
+    "--inspect",
+    help="If true, allows the user to inspect the state of the task after it has finished running",
+    is_flag=True,
+    default=False,
+    show_default=True,
+)
+@click.argument(
+    "task_pathspec",
+)
+@click.pass_obj
+def task(
+    obj,
+    task_pathspec: str,
+    metaflow_root_dir: str,
+    override_env: Optional[str] = None,
+    override_env_from_pathspec: Optional[str] = None,
+    inspect: bool = False,
+):
+    """
+    Create a new remote instance based on named_env name or pathspec.
+    """
+    # Move logic to _execute_local_backend to make it reusable
+    _execute_local_backend(
+        obj,
+        task_pathspec,
+        metaflow_root_dir,
+        override_env,
+        override_env_from_pathspec,
+        inspect,
+    )
+
+
+def _execute_local_backend(
+    obj,
+    task_pathspec: str,
+    metaflow_root_dir: str,
+    override_env: Optional[str] = None,
+    override_env_from_pathspec: Optional[str] = None,
+    inspect: bool = False,
+):
+    """
+    Executes the local backend for the task.
+
+    Parameters
+    ----------
+    obj : CommandObj
+        The command object.
+    task_pathspec : str
+        The pathspec of the task.
+    metaflow_root_dir : str
+        The root directory where the debug scripts should be generated.
+    override_env : Optional[str], optional, default None
+        Name of the named environment to use for debugging the task. Overrides the environment used in the Task.
+    override_env_from_pathspec : Optional[str], optional, default None
+        Pathspec to use as environment for debugging the task. Overrides the environment used in the Task.
+    inspect : bool, optional, default False
+        If true, allows the user to inspect the state of the task after it has finished running.
+    """
+    cur_task = Task(task_pathspec, _namespace_check=False)
+    if "code-package" not in cur_task.metadata_dict:
+        raise CommandException(
+            "Task {} does not have code-package. `debug task command only supports "
+            "tasks that were executed remotely.".format(task_pathspec)
+        )
+    python_executable = _set_python_environment(
+        obj, cur_task, task_pathspec, override_env, override_env_from_pathspec
+    )
+    obj.echo(
+        "Python executable path for debugging is set to {}".format(python_executable)
+    )
+    obj.echo(
+        "Generating debug scripts for task {} using local backend".format(task_pathspec)
+    )
+    # We download the code package from the task, extract it, generate the escape trampolines,
+    # and then generate the debug scripts
+    _extract_code_package(obj, cur_task, metaflow_root_dir)
+    _generate_escape_trampolines(metaflow_root_dir)
+    _generate_debug_scripts(
+        obj,
+        task_pathspec,
+        metaflow_root_dir,
+        inspect,
+        generate_notebook="true",
+        python_executable=python_executable,
+    )
+
+
+def _generate_debug_scripts(
+    obj,
+    task_pathspec: str,
+    metaflow_root_dir: str,
+    inspect: str,
+    generate_notebook: str,
+    python_executable: Optional[str] = None,
+):
+    """
+    Generates the debug scripts for the task.
+
+    Parameters
+    ----------
+    obj : CommandObj
+        The command object.
+    task_pathspec : str
+        The pathspec of the task.
+    metaflow_root_dir : str
+        The root directory where the debug scripts should be generated.
+    inspect : str
+        If 'true' or '1', generates script to inspect the state of the task after it has finished running.
+    generate_notebook : str
+        If 'true' or '1', setup a notebook with debugging params.
+    python_executable : Optional[str], optional, default None
+        The python executable path for the debug task.
+    """
+    os.makedirs(metaflow_root_dir, exist_ok=True)
+    python_executable = python_executable.strip() if python_executable else None
+    flow_name = task_pathspec.split("/")[0]
+    debug_file_name = task_pathspec.replace("/", "_").replace("-", "_") + "_debug.py"
+    debug_script_generator = DebugScriptGenerator(task_pathspec, inspect)
+    script = debug_script_generator.generate_debug_script(metaflow_root_dir, flow_name)
+    debug_script_generator.write_debug_script(
+        metaflow_root_dir, script, debug_file_name
+    )
+
+    generate_notebook = generate_notebook.lower() in ["true", "1"]
+    if generate_notebook:
+        kernel_def = _find_kernel_name(python_executable)
+        if kernel_def:
+            obj.echo(
+                f"Jupyter kernel name: {kernel_def[0]} with display name: {kernel_def[1]}"
+            )
+        notebook_json = debug_script_generator.generate_debug_notebook(
+            metaflow_root_dir, debug_file_name, kernel_def
+        )
+        debug_script_generator.write_debug_notebook(metaflow_root_dir, notebook_json)
+
+    obj.echo(
+        f"Debug scripts and notebook generated at {metaflow_root_dir}",
+        fg="green",
+        bold=True,
+    )
+
+    # We copy the stub generators to the metaflow root directory as the stub generators
+    # may not be present in the metaflow version that the user is using.
+    copy_stub_generator_to_metaflow_root_dir(metaflow_root_dir)

--- a/metaflow_extensions/netflix_ext/cmd/debug/debug_script_generator.py
+++ b/metaflow_extensions/netflix_ext/cmd/debug/debug_script_generator.py
@@ -1,0 +1,484 @@
+import os
+import json
+import textwrap
+from typing import List, Dict, Any, Optional, Tuple, Union
+from metaflow import Step
+from metaflow_extensions.nflx.cmd.debug.constants import Constants
+from metaflow_extensions.nflx.cmd.debug.debug_utils import fetch_environment_type
+from metaflow_extensions.nflx.cmd.debug.debug_stub_generator import DebugStubGenerator
+
+
+class DebugScriptGenerator(object):
+    def __init__(self, task_pathspec: str, inspect: Union[str, bool]):
+        """
+        Initializes the debugScriptGenerator.
+
+        Parameters
+        ----------
+        task_pathspec : str
+            The pathspec of the task.
+        inspect : Union[str, bool]
+            The inspect flag.
+        """
+        self.task_pathspec = task_pathspec
+        if isinstance(inspect, bool):
+            self.inspect = inspect
+        else:
+            self.inspect = True if inspect.lower() in ("true", "1") else False
+        self.debug_stub_generator = DebugStubGenerator(task_pathspec)
+
+    def namespace_imports(self, script: str) -> str:
+        """
+        Appends the namespace imports to the script.
+
+        Parameters
+        ----------
+        script : str
+            The script for the step.
+
+        Returns
+        -------
+        str
+            The script with the namespace imports appended.
+        """
+        script += textwrap.dedent(
+            Constants.CURRENT_TASK_NAMESPACE_STUB.format(
+                Namespace=self.debug_stub_generator.task_namespace
+            )
+        )
+        return script
+
+    def append_imports(self, metaflow_root_dir: str, script: str) -> str:
+        """
+        Appends the imports to the script.
+
+        Parameters
+        ----------
+        metaflow_root_dir : str
+            The root directory of the Metaflow installation.
+        script : str
+            The script for the step.
+
+        Returns
+        -------
+        str
+            The script with the imports appended.
+        """
+        script += textwrap.dedent(
+            Constants.IMPORTS_STUB.format(
+                MetaflowEnvEscapeDir=os.path.join(
+                    metaflow_root_dir, "_escape_trampolines"
+                ),
+                MetaflowFileName=self.debug_stub_generator.file_name.split(".")[0],
+            )
+        )
+        return script
+
+    def append_workbench_instantiation(self, script: str) -> str:
+        """
+        Appends the debug stub generator instantiation to the script.
+
+        Parameters
+        ----------
+        script : str
+            The script for the step.
+
+        Returns
+        -------
+        str
+            The script with the debug stub generator instantiation appended.
+        """
+        script += textwrap.dedent(
+            Constants.DEBUG_STUB_GENERATOR_INSTANTIATION_TEMPLATE.format(
+                TaskPathspec=self.task_pathspec
+            )
+        )
+        return script
+
+    @staticmethod
+    def append_stubbed_classes(flow_name: str, script: str) -> str:
+        """
+        Appends the stubs to the script.
+
+        Parameters
+        ----------
+        flow_name : str
+            The name of the flow.
+        script : str
+            The script for the step.
+
+        Returns
+        -------
+        str
+            The script with the stubs appended.
+        """
+        script += textwrap.dedent(
+            Constants.DEBUG_INPUT_ITEM_STUB.format(
+                FlowSpecClass=flow_name,
+            )
+        )
+        script += textwrap.dedent(
+            Constants.DEBUG_INPUT_STUB.format(
+                FlowSpecClass=flow_name,
+            )
+        )
+        script += textwrap.dedent(
+            Constants.DEBUG_LINEAR_STEP_STUB.format(
+                FlowSpecClass=flow_name,
+            )
+        )
+        script += textwrap.dedent(
+            Constants.DEBUG_JOIN_STEP_STUB.format(
+                FlowSpecClass=flow_name,
+            )
+        )
+        return script
+
+    def append_join_step_instantiation(self, script: str) -> str:
+        """
+        Appends the join step instantiation to the script.
+
+        Parameters
+        ----------
+        script : str
+            The script for the step.
+
+        Returns
+        -------
+        str
+            The script with the join step instantiation appended.
+        """
+        template = (
+            Constants.JOIN_STUB_INSPECT_INSTANTIATION_TEMPLATE
+            if self.inspect
+            else Constants.JOIN_STUB_INSTANTIATION_TEMPLATE
+        )
+        script += textwrap.dedent(template)
+        return script
+
+    def append_linear_step_instantiation(self, script: str) -> str:
+        """
+        Appends the linear step instantiation to the script.
+
+        Parameters
+        ----------
+        script : str
+            The script for the step.
+
+        Returns
+        -------
+        str
+            The script with the linear step instantiation appended.
+        """
+        template = (
+            Constants.LINEAR_STUB_INSPECT_INSTANTIATION_TEMPLATE
+            if self.inspect
+            else Constants.LINEAR_STUB_INSTANTIATION_TEMPLATE
+        )
+        script += textwrap.dedent(template)
+        return script
+
+    def append_start_step_instantiation(self, script: str) -> str:
+        """
+        Appends the start step instantiation to the script.
+
+        Parameters
+        ----------
+        script : str
+            The script for the step.
+
+        Returns
+        -------
+        str
+            The script with the start step instantiation appended.
+        """
+        _run_pathspec = "/".join(self.task_pathspec.split("/")[:2])
+        prev_task = Step(
+            os.path.join(_run_pathspec, "_parameters"), _namespace_check=False
+        ).task
+        template = (
+            Constants.START_STUB_INSPECT_INSTANTIATION_TEMPLATE
+            if self.inspect
+            else Constants.START_STUB_INSTANTIATION_TEMPLATE
+        )
+        script += textwrap.dedent(template.format(ParameterTask=prev_task.pathspec))
+        return script
+
+    def append_current_stub_instantiation(self, script: str) -> str:
+        """
+        Appends the current stub instantiation to the script.
+
+        Parameters
+        ----------
+        script : str
+            The script for the step.
+
+        Returns
+        -------
+        str
+            The script with the current stub instantiation appended.
+        """
+        script += textwrap.dedent(
+            Constants.CURRENT_STUB_INSTANTIATION_TEMPLATE.format(
+                TaskPathspec=self.task_pathspec
+            )
+        )
+        return script
+
+    @staticmethod
+    def write_debug_script(
+        metaflow_root_dir: str, debug_script: str, debug_file_name: str
+    ) -> None:
+        """
+        Writes the debug script for the step.
+
+        Parameters
+        ----------
+        metaflow_root_dir : str
+            The root directory of the Metaflow installation.
+        debug_script : str
+            The debug script for the step.
+        debug_file_name : str
+            The name of the debug script.
+        """
+        debug_script_path = os.path.join(metaflow_root_dir, debug_file_name)
+        with open(debug_script_path, "w") as f:
+            f.write(debug_script)
+
+    def generate_debug_script(self, metaflow_root_dir: str, flow_name: str) -> str:
+        """
+        Generates the debug script for the step.
+
+        Parameters
+        ----------
+        metaflow_root_dir : str
+            The root directory of the Metaflow installation.
+        flow_name : str
+            The name of the flow.
+
+        Returns
+        -------
+        str
+            The debug script for the step.
+        """
+        print("Generating debug script for task: {}".format(self.task_pathspec))
+        # We first write out the imports
+        debug_script = self.append_imports(metaflow_root_dir, "")
+
+        # We then write out the namespace imports
+        debug_script = self.namespace_imports(debug_script)
+
+        # We then write out the stubbed classes
+        debug_script = self.append_stubbed_classes(flow_name, debug_script)
+
+        # We instantiate the current stub generator
+        debug_script = self.append_current_stub_instantiation(debug_script)
+
+        # We instantiate the debug stub generator
+        debug_script = self.append_workbench_instantiation(debug_script)
+
+        # We then write out the stubs instantiation
+        if self.debug_stub_generator.step_type == "start":
+            debug_script = self.append_start_step_instantiation(debug_script)
+        elif self.debug_stub_generator.step_type == "join":
+            debug_script = self.append_join_step_instantiation(debug_script)
+        else:
+            debug_script = self.append_linear_step_instantiation(debug_script)
+
+        return debug_script
+
+    def generate_debug_notebook(
+        self,
+        metaflow_root_dir: str,
+        debug_file_name: str,
+        kernel_def: Optional[Tuple[str, str]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Generates the debug notebook for the task.
+
+        Parameters
+        ----------
+        metaflow_root_dir : str
+            The root directory of the Metaflow installation.
+        debug_file_name : str
+            The name of the debug script
+        kernel_def : Optional[Tuple[str, str]], optional, default None
+            The kernel definition containing the kernel name and the kernel display name.
+
+        Returns
+        -------
+        Dict[str, Any]
+            The dictionary representing the debug notebook for the task.
+        """
+        # We first generate the notebook cells
+        notebook_cells = self.generate_notebook_cells(
+            metaflow_root_dir, debug_file_name
+        )
+
+        # We then generate the notebook JSON
+        notebook_json = self.generate_notebook_json(notebook_cells, kernel_def)
+        return notebook_json
+
+    @staticmethod
+    def write_debug_notebook(
+        metaflow_root_dir: str, notebook_json: Dict[str, Any]
+    ) -> None:
+        """
+        Writes the debug notebook for the task.
+
+        Parameters
+        ----------
+        metaflow_root_dir : str
+            The root directory of the Metaflow installation.
+        notebook_json : Dict[str, Any]
+            The name of the debug notebook.
+        """
+        # We then write out the notebook JSON
+        debug_notebook_name = "00_DEBUG_ME.ipynb"
+        debug_notebook_path = os.path.join(metaflow_root_dir, debug_notebook_name)
+        with open(debug_notebook_path, "w") as f:
+            json.dump(notebook_json, f, indent=4)
+
+    @staticmethod
+    def generate_notebook_json(
+        notebook_cells: List[Dict[str, Any]],
+        kernel_def: Optional[Tuple[str, str]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Generates the notebook JSON for the task.
+
+        Parameters
+        ----------
+        notebook_cells : List[Dict[str, Any]]
+            The list of notebook cells.
+        kernel_def : Optional[Tuple[str, str]], optional, default None
+            The kernel definition containing the kernel name and the kernel display name.
+
+        Returns
+        -------
+        Dict[str, Any]
+            The notebook JSON for the task.
+        """
+        # Create an empty notebook
+        nb = {
+            "cells": [],
+            "metadata": {}
+            if kernel_def is None
+            else {
+                "kernelspec": {
+                    "name": kernel_def[0],
+                    "display_name": kernel_def[1],
+                    "language": "python",
+                }
+            },
+            "nbformat": 4,
+            "nbformat_minor": 4,
+        }
+
+        # Add cells to the notebook
+        for cell in notebook_cells:
+            nb_cell = {
+                "cell_type": cell.get("format"),
+                "execution_count": None,
+                "metadata": {},
+                "outputs": [],
+                "source": [cell.get("content")],
+            }
+            nb["cells"].append(nb_cell)
+
+        return nb
+
+    def get_function_definition(self, metaflow_root_dir: str) -> Tuple[str, int]:
+        """
+        Returns the function definition and the end line number for the task.
+
+        Parameters
+        ----------
+        metaflow_root_dir : str
+            The root directory of the Metaflow installation.
+
+        Returns
+        -------
+        Tuple[str, int]
+            The function definition and the end line number for the task.
+        """
+        with open(
+            os.path.join(metaflow_root_dir, self.debug_stub_generator.file_name), "r"
+        ) as f:
+            step_started = False
+            function_definition = ""
+            for i, line in enumerate(f):
+                if i == self.debug_stub_generator.task_line_num:
+                    step_started = True
+
+                if step_started:
+                    function_definition += line
+                    if "self.next(self." in line:
+                        return function_definition, i
+
+    def generate_notebook_cells(
+        self, metaflow_root_dir: str, debug_file_name: str
+    ) -> List[Dict[str, Any]]:
+        """
+        Generates the notebook cells for the task.
+
+        Parameters
+        ----------
+        metaflow_root_dir : str
+            The root directory of the Metaflow installation.
+        debug_file_name : str
+            The name of the debug notebook.
+
+        Returns
+        -------
+        str
+            The notebook cells for the task.
+        """
+        # We first add a markdown cell stating that it is a debugging notebook
+        notebook_cells = [
+            {
+                "format": "markdown",
+                "content": Constants.JUPYTER_TITLE_MARKDOWN.format(
+                    TaskPathSpec=self.task_pathspec,
+                    DebugType="Post-Execution State"
+                    if self.inspect
+                    else "Pre-Execution State",
+                ),
+            }
+        ]
+
+        # We now add a code cell that incorporates the Metaflow escape hatch
+        # We only add this if the user code ran in a conda environment
+        if fetch_environment_type(self.debug_stub_generator.task) != "default":
+            script = textwrap.dedent(
+                Constants.ESCAPE_HATCH_STUB.format(
+                    MetaflowEnvEscapeDir=os.path.abspath(
+                        os.path.join(metaflow_root_dir, "_escape_trampolines")
+                    )
+                )
+            )
+            notebook_cells.append({"format": "code", "content": script.strip()})
+
+        # We now add a code cell that imports the debugging modules
+        script = "from {} import * ".format(debug_file_name.split(".")[0])
+        notebook_cells.append({"format": "code", "content": script})
+
+        # We now add a markdown cell that tells the user to add their own code
+        flow_file_name = self.debug_stub_generator.file_name
+        start_line_num = self.debug_stub_generator.task_line_num
+        function_definition, end_line_num = self.get_function_definition(
+            metaflow_root_dir
+        )
+        markdown_content = Constants.JUPYTER_INSTRUCTIONS_MARKDOWN.format(
+            FileName=flow_file_name,
+            StepStartLine=start_line_num,
+            StepEndLine=end_line_num,
+            FunctionDefinition=textwrap.dedent(function_definition),
+        )
+        notebook_cells.append(
+            {"format": "markdown", "content": textwrap.dedent(markdown_content.strip())}
+        )
+
+        # Add an empty cell for the user to add their own code
+        notebook_cells.append({"format": "code", "content": ""})
+        return notebook_cells

--- a/metaflow_extensions/netflix_ext/cmd/debug/debug_script_generator.py
+++ b/metaflow_extensions/netflix_ext/cmd/debug/debug_script_generator.py
@@ -74,7 +74,7 @@ class DebugScriptGenerator(object):
         )
         return script
 
-    def append_workbench_instantiation(self, script: str) -> str:
+    def append_debug_stub_instantiation(self, script: str) -> str:
         """
         Appends the debug stub generator instantiation to the script.
 
@@ -275,7 +275,7 @@ class DebugScriptGenerator(object):
         debug_script = self.append_current_stub_instantiation(debug_script)
 
         # We instantiate the debug stub generator
-        debug_script = self.append_workbench_instantiation(debug_script)
+        debug_script = self.append_debug_stub_instantiation(debug_script)
 
         # We then write out the stubs instantiation
         if self.debug_stub_generator.step_type == "start":

--- a/metaflow_extensions/netflix_ext/cmd/debug/debug_stub_generator.py
+++ b/metaflow_extensions/netflix_ext/cmd/debug/debug_stub_generator.py
@@ -1,0 +1,188 @@
+import os
+
+from typing import Dict, List, Any
+from metaflow import Task, namespace, Step
+from metaflow.plugins.env_escape import generate_trampolines
+
+
+class DebugStubGenerator(object):
+    def __init__(self, task_pathspec):
+        """
+        Initializes the WorkbenchStubGenerator.
+
+        Parameters
+        ----------
+        task_pathspec : str
+            The pathspec of the task.
+        """
+        self.task_pathspec = task_pathspec
+        self.task = Task(task_pathspec, _namespace_check=False)
+        self.step_name = self.task.parent.id
+        self.run_id = self.task.parent.parent.id
+        self.flow_name = self.task.parent.parent.parent.id
+        self.is_new_conda_step = self.is_new_conda_step()
+        self.workflow_dag = self.task["_graph_info"].data
+        self.file_name = self.workflow_dag["file"]
+        self._dag_structure = self.get_dag_structure(self.workflow_dag["steps"])
+        self.step_type = self.get_step_type(self.step_name)
+        self._previous_nodes = self.find_previous_nodes(
+            self.step_name, self._dag_structure
+        )
+        self.task_line_num = self._dag_structure[self.step_name]["line"]
+        self.node = self._dag_structure[self.step_name]
+        self.previous_steps = self.get_previous_steps(self._previous_nodes)
+        self.previous_tasks = self.get_previous_tasks(self.previous_steps)
+        self.task_namespace = self.get_task_namespace()
+
+    @staticmethod
+    def get_dag_structure(dag: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Returns the simplified DAG structure of the workflow.
+
+        Parameters:
+        ----------
+        dag : Dict[str, Any]
+            The DAG structure of the workflow.
+        Returns:
+        ----------
+        Dict[str, Any]
+            Simplified DAG structure of the workflow.
+        """
+        dag_structure = {}
+        for node, attributes in dag.items():
+            dag_structure[node] = {
+                "next": attributes["next"],
+                "type": attributes["type"],
+                "line": attributes["line"],
+            }
+        return dag_structure
+
+    def is_new_conda_step(self) -> bool:
+        """
+        Returns True if the step is a new conda step, False otherwise.
+
+        Returns:
+        ----------
+        bool
+            True if the step is a new conda step, False otherwise.
+        """
+        return "conda_env_id" in self.task.metadata_dict
+
+    def get_step_type(self, step_name: str) -> str:
+        """
+        Returns the type of the step.
+
+        Parameters
+        ----------
+        step_name : str
+            The name of the step.
+
+        Returns
+        -------
+        str
+            The type of the step.
+        """
+        return self._dag_structure[step_name]["type"]
+
+    @staticmethod
+    def find_previous_nodes(node: str, dag_structure: Dict[str, Any]) -> List[str]:
+        """
+        Returns the previous nodes for a given node.
+
+        Parameters
+        ----------
+        node : str
+            The name of the node to find the previous nodes for.
+        dag_structure : Dict[str, Any]
+            The DAG structure of the workflow.
+
+        Returns
+        -------
+        List[str]
+            The list of previous nodes.
+        """
+        if node == "start":
+            return []
+        previous_nodes = []
+        for node_name, attributes in dag_structure.items():
+            if node in attributes["next"]:
+                previous_nodes.append(node_name)
+        return previous_nodes
+
+    @staticmethod
+    def get_join_type(previous_steps: List[Step]) -> str:
+        """
+        Returns the type of join for the step.
+
+        Parameters
+        ----------
+        previous_steps : List[Step]
+            The list of previous steps.
+
+        Returns
+        -------
+        str
+            The type of join for the step.
+        """
+        return "foreach" if len(previous_steps) == 1 else "static"
+
+    def get_previous_steps(self, previous_nodes: List[str]) -> List[Step]:
+        """
+        Returns the previous steps for a given step.
+
+        Parameters
+        ----------
+        previous_nodes : List[str]
+            The list of previous nodes.
+
+        Returns
+        -------
+        List[Step]
+            The list of previous steps.
+        """
+        return [
+            Step(
+                "{}/{}/{}".format(self.flow_name, self.run_id, n),
+                _namespace_check=False,
+            )
+            for n in previous_nodes
+        ]
+
+    def get_previous_tasks(self, previous_steps: List[Step]) -> List[Task]:
+        """
+        Returns the previous tasks for a given step.
+
+        Parameters
+        ----------
+        previous_steps : List[Step]
+            The list of previous steps.
+
+        Returns
+        -------
+        List[Task]
+            The list of previous tasks.
+        """
+        step_type = self.get_step_type(self.step_name)
+        if step_type == "join" and self.get_join_type(self.previous_steps) == "foreach":
+            return sorted(
+                [task for task in previous_steps[0].tasks()], key=lambda x: x.index
+            )
+        # If the step is linear, split-foreach, split-static or a static-join, then we just return the
+        # tasks in the order they were run.
+        return [step.task for step in previous_steps]
+
+    def get_task_namespace(self) -> str:
+        """
+        Returns the namespace of the task.
+
+        Returns
+        -------
+        str
+            The namespace of the task.
+        """
+        task_namespace = None
+        for val in self.task.tags:
+            if val.startswith("production:") or val.startswith("user:"):
+                task_namespace = val
+                break
+        return task_namespace

--- a/metaflow_extensions/netflix_ext/cmd/debug/debug_stub_generator.py
+++ b/metaflow_extensions/netflix_ext/cmd/debug/debug_stub_generator.py
@@ -8,7 +8,7 @@ from metaflow.plugins.env_escape import generate_trampolines
 class DebugStubGenerator(object):
     def __init__(self, task_pathspec):
         """
-        Initializes the WorkbenchStubGenerator.
+        Initializes the DebugStubGenerator.
 
         Parameters
         ----------

--- a/metaflow_extensions/netflix_ext/cmd/debug/debug_utils.py
+++ b/metaflow_extensions/netflix_ext/cmd/debug/debug_utils.py
@@ -1,0 +1,249 @@
+import os
+import sys
+import json
+import shutil
+import traceback
+import subprocess
+from metaflow import Task, S3
+from typing import Any, Dict, Optional, Tuple
+from metaflow.exception import CommandException
+from metaflow.plugins.env_escape import generate_trampolines
+from metaflow_extensions.nflx.cmd.debug.constants import Constants
+
+
+def get_code_package_location(task: Task) -> str:
+    """
+    Gets the code package location for the task.
+
+    Parameters
+    ----------
+    task : Task
+        The task object.
+
+    Returns
+    -------
+    str
+        The code package location for the task.
+    """
+    code_package = task.metadata_dict.get("code-package", "").strip()
+    code_package = json.loads(code_package)
+    return code_package.get("location")
+
+
+def get_python_version(task: Task) -> str:
+    """
+    Gets the python version for the task.
+
+    Parameters
+    ----------
+    task : Task
+        The task object.
+
+    Returns
+    -------
+    str
+        The python version for the task.
+    """
+    python_version = task.metadata_dict.get(
+        "python_version", Constants.DEFAULT_PYTHON_VERSION
+    )
+    return ".".join(python_version.split(".")[:2])
+
+
+def copy_stub_generator_to_metaflow_root_dir(metaflow_root_dir: str):
+    """
+    Copies the debug and current stub generator to the metaflow root directory.
+
+    Parameters
+    ----------
+    metaflow_root_dir : str
+        The metaflow root directory.
+    """
+    debug_stub_generator_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "debug_stub_generator.py",
+    )
+    current_stub_generator_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "current_stub_generator.py",
+    )
+    shutil.copy(debug_stub_generator_path, metaflow_root_dir)
+    shutil.copy(current_stub_generator_path, metaflow_root_dir)
+
+
+def fetch_environment_type(task: Task) -> str:
+    """
+    Fetches the conda environment type for the task.
+
+    Parameters
+    ----------
+    task : Task
+        The task object.
+
+    Returns
+    -------
+    str
+        The conda environment type for the task.
+    """
+    conda_env_id = task.metadata_dict.get("conda_env_id", "").strip()
+    if conda_env_id == "":
+        return "default"
+    elif conda_env_id.startswith("[") and conda_env_id.endswith("]"):
+        return "new_conda"
+    raise CommandException(
+        "The conda environment type for the task is not supported. Please use the new conda decorators avaailable in "
+        "Metaflow."
+    )
+
+
+def _set_python_environment(
+    obj,
+    task: Task,
+    task_pathspec: str,
+    override_env: Optional[str] = None,
+    override_env_from_pathspec: Optional[str] = None,
+) -> str:
+    """
+    Sets the python environment for the debug task.
+
+    Parameters
+    ----------
+    obj : Any
+        The command object.
+    task : Task
+        The task object.
+    task_pathspec : str
+        The pathspec of the task.
+    override_env : Optional[str], optional, default None
+        Name of the named environment to use for debugging the task. Overrides the environment used in the Task.
+    override_env_from_pathspec : Optional[str], optional, default None
+        Pathspec to use as environment for debugging the task. Overrides the environment used in the Task.
+
+    Returns
+    -------
+    str
+        The path to the python executable for the debug task.
+
+    """
+    if override_env is not None and override_env_from_pathspec is not None:
+        raise CommandException(
+            "Only one of --override-env and --override-env-from-pathspec can be specified"
+        )
+
+    conda_environment_type = fetch_environment_type(task)
+    path_spec = "/".join(task_pathspec.split("/")[:-1])
+    path_spec_formatted = path_spec.replace("/", "_").replace("-", "_")
+    mf_python_path, mf_env, mf_env_name = sys.executable, None, None
+    obj.echo(f"Conda environment type: {conda_environment_type}")
+
+    if conda_environment_type == "new_conda":
+        mf_env_name = override_env if override_env else path_spec_formatted.lower()
+        path_spec = (
+            override_env_from_pathspec if override_env_from_pathspec else path_spec
+        )
+        mf_env = [override_env] if override_env else ["--pathspec", f"{path_spec}"]
+        obj.echo(
+            f"Creating conda environment: {mf_env_name} with pathspec: {path_spec}"
+        )
+        conda_command = [
+            "metaflow",
+            "environment",
+            "--quiet",
+            "create",
+            "--name",
+            mf_env_name,
+            "--install-notebook",
+            "--force",
+        ]
+        conda_command.extend(mf_env)
+        # Check if the pathspec is a conda environment
+        try:
+            result = subprocess.run(
+                conda_command,
+                check=True,
+                capture_output=True,
+            )
+            # We have to parse the stderr and find the exact line where the python path is present
+            for line in result.stderr.decode().split("\n"):
+                if "/bin/python" in line:
+                    mf_python_path = line
+                    break
+            return mf_python_path
+        except subprocess.CalledProcessError as e:
+            raise CommandException(
+                f"Error creating conda environment: {e.stderr.decode()}"
+            )
+        except Exception as e:
+            raise CommandException("Setting python environment failed: {}".format(e))
+    return mf_python_path
+
+
+def _extract_code_package(obj, task: Task, metaflow_root_dir: str):
+    """
+    Extracts the code package for the task in the metaflow root directory.
+
+    Parameters
+    ----------
+    obj : Any
+        The command object.
+    task : Task
+        The task object.
+    metaflow_root_dir : str
+        The metaflow root directory.
+    """
+    os.makedirs(metaflow_root_dir, exist_ok=True)
+    code_package_path = os.path.join(metaflow_root_dir, "code_package.tar.gz")
+    code_package_location = get_code_package_location(task)
+    try:
+        with S3() as s3:
+            res = s3.get(code_package_location)
+            with open(code_package_path, "wb") as f:
+                f.write(res.blob)
+
+        # We now untar the code package
+        shutil.unpack_archive(code_package_path, metaflow_root_dir)
+        obj.echo(f"Code package extracted to {metaflow_root_dir}")
+    except Exception as e:
+        raise CommandException(
+            "Error in downloading or extracting code package: {}".format(e)
+        )
+
+
+def _find_kernel_name(
+    python_executable: Optional[str] = None,
+) -> Optional[Tuple[str, str]]:
+    """
+    Finds the jupyter kernel name for the python executable. This is a best effort
+    function and may potentially fail in some cases. We return None in those cases
+    and will not set the kernel in the generated notebook.
+
+    Parameters
+    ----------
+    python_executable : Optional[str], optional, default None
+        The python executable path.
+
+    Returns
+    -------
+    Optional[Tuple[str, str]]
+        The kernel name and the kernel's display name if found, None otherwise.
+    """
+    try:
+        output = subprocess.check_output(["jupyter", "kernelspec", "list", "--json"])
+        kernelspecs = json.loads(output)
+        for kernel_name, kernel_spec in kernelspecs["kernelspecs"].items():
+            if kernel_spec["spec"]["argv"][0] == python_executable:
+                return kernel_name, kernel_spec["spec"]["display_name"]
+    except Exception as e:
+        # Ignore the exception and return None as it is a best effort function
+        print(f"Error finding kernel name: {traceback.format_exc()}")
+        pass
+    return None
+
+
+def _generate_escape_trampolines(metaflow_root_dir: str):
+    """
+    Generates the escape trampolines for the task.
+    """
+    trampoline_dir = os.path.join(metaflow_root_dir, "_escape_trampolines")
+    os.makedirs(trampoline_dir, exist_ok=True)
+    generate_trampolines(trampoline_dir)

--- a/metaflow_extensions/netflix_ext/cmd/debug/jupyter_instructions_markdown.py
+++ b/metaflow_extensions/netflix_ext/cmd/debug/jupyter_instructions_markdown.py
@@ -1,0 +1,24 @@
+_jupyter_instructions_markdown = """
+### Instructions for Debugging 
+
+##### 1. Execute the previous cells before running the code cell below.
+
+##### 2. Select the correct kernel for the notebook.
+- By default, the kernel was selected based on the environment we created for 
+debugging the task. In case the kernel is not selected correctly, 
+follow the steps given below.
+- If the task originally ran in a conda environment, select the kernel whose 
+display name starts with `Metaflow ...`. Else, select any python kernel 
+available.
+
+##### 3. Add the code for the Task in the cells below!
+- The code for the task is in the file `{FileName}` and the step begins from 
+line no: `{StepStartLine}` and ends at line no: `{StepEndLine}`. 
+- You can copy the code inside the function definition and execute it line 
+  by line (or however you want) to debug the task as you wish. 
+- The function definition has also been provided below for reference:
+
+```python
+{FunctionDefinition}
+```
+"""

--- a/metaflow_extensions/netflix_ext/cmd/debug/jupyter_title_markdown.py
+++ b/metaflow_extensions/netflix_ext/cmd/debug/jupyter_title_markdown.py
@@ -1,0 +1,15 @@
+_jupyter_title_markdown = """
+# Debugging Notebook for Task: {TaskPathSpec}
+
+### Debug Type: {DebugType}
+
+- A `Pre-Execution State` debug type implies that you can inspect the state of 
+the task before it began execution. 
+- For instance, if the current Metaflow step is called `stepB` and the 
+previous step was `stepA`, then you are essentially debugging the state 
+after `stepA` finished execution and before `stepB` began execution.
+- In case of a `Post-Execution State` debug type, you can inspect the state 
+of the task after it has finished execution. In this case, you can inspect 
+the state of the task after `stepB` has finished execution, and before any 
+succeeding step has started.
+"""

--- a/metaflow_extensions/netflix_ext/cmd/mfextinit_netflixext.py
+++ b/metaflow_extensions/netflix_ext/cmd/mfextinit_netflixext.py
@@ -1,1 +1,4 @@
-CMDS_DESC = [("environment", ".environment.environment_cmd.cli")]
+CMDS_DESC = [
+    ("debug", ".debug.debug_cmd.cli"),
+    ("environment", ".environment.environment_cmd.cli")
+]


### PR DESCRIPTION
## Debugging Extension
This extension allows user's to seamlessly debug their executed steps in an isolated Jupyter notebook instance with appropriate dependencies by leveraging the conda extensions. 

### Executing the command
Let's say you have a step called `fit_gbrt_for_given_param` in your flow, and on executing it, the pathspec for this step/task is `HousePricePredictionFlow/1199/fit_gbrt_for_given_param/150671013`. To debug this step, you can run the command:

```bash
metaflow debug task <HousePricePredictionFlow/1199/fit_gbrt_for_given_param/150671013> --metaflow-root-dir ~/notebooks/debug_task`
```
### Using the extension
Running the above command will download your code package, download the appropriate conda/pip packages defined for that particular step (if you use the conda extension), and generate stubs to access the relevant artifacts for that particular run. It will additionally generate a notebook in the defined directory where you can debug the execution of your step line by line. For the given step definition:
```python
@step
def fit_gbrt_for_given_param(self):
    """
    Fit GBRT with given parameters
    """

    from sklearn import ensemble
    from sklearn.model_selection import cross_val_score
    import numpy as np


    estimator = ensemble.GradientBoostingRegressor( n_estimators = self.input['n_estimators'], learning_rate = self.input['learning_rate'],
        max_depth = self.input['max_depth'], min_samples_split = 2, loss = 'ls')

    estimator.fit(self.features, self.labels)

    mses = cross_val_score(estimator, self.features, self.labels, cv = 5, scoring='neg_mean_squared_error')
    rmse = np.sqrt(-mses).mean()


    self.fit = dict(
        index=int(self.index),
        params=self.input,
        rmse=rmse,
        estimator=estimator
    )

    self.next(self.select_best_model)
```

You will be able to access the artifacts/inputs in your generated notebook directly:
```python
>>> print(self.input['n_estimatos'])  # You can access objects using `self` as we imported a stub for it in the notebook
>>> print(self.input['learning_rate'])
```

You can also execute the whole function again:
```python
>>> from sklearn import ensemble  # imports work seamlessly due to conda extension
>>> from sklearn.model_selection import cross_val_score
>>> import numpy as np
>>> estimator = ensemble.GradientBoostingRegressor( n_estimators = self.input['n_estimators'], learning_rate = self.input['learning_rate'],
    max_depth = self.input['max_depth'], min_samples_split = 2, loss = 'ls')
>>> estimator.fit(self.features, self.labels)
>>> mses = cross_val_score(estimator, self.features, self.labels, cv = 5, scoring='neg_mean_squared_error')
>>> rmse = np.sqrt(-mses).mean()
>>> self.fit = dict(
    index=int(self.index),
    params=self.input,
    rmse=rmse,
    estimator=estimator
)
```

You can examine the effects of other hyper-parameters live by modifying the `min_samples_split = 3` and re-executing the steps on the same data. 
