### PR TITLE
Use bash binary from current environment

### DIFF
--- a/metaflow_extensions/netflix_ext/plugins/conda/conda.py
+++ b/metaflow_extensions/netflix_ext/plugins/conda/conda.py
@@ -1779,7 +1779,7 @@ class Conda(object):
 
     def _ensure_micromamba(self) -> str:
         args = [
-            "/bin/bash",
+            "bash",
             "-c",
             "if ! type micromamba  >/dev/null 2>&1; then "
             "mkdir -p ~/.local/bin >/dev/null 2>&1; "


### PR DESCRIPTION
Some Linux distributions such as NixOS do not have bash installed at /bin/bash. We resolve the bash binary in `$PATH`.