### PR TITLE
Various fixes reported by users

### DIFF
--- a/docs/conda.md
+++ b/docs/conda.md
@@ -144,7 +144,7 @@ print an error message warning you that it is waiting for a certain lock file to
 prior to proceeding.
 
 Removing the file will typically allow Metaflow to proceed. You can also set the amount of time
-Metaflow waits before warning you by setting `METAFLOW_CONDA_LOCK_TIMEOUT` which is currently set
+Metaflow waits before giving up by setting `METAFLOW_CONDA_LOCK_TIMEOUT` which is currently set
 to 300 seconds (5 minutes).
 
 ## Troubleshooting

--- a/docs/conda.md
+++ b/docs/conda.md
@@ -136,6 +136,17 @@ You can get a significant performance gain if you use only `.conda` packages and
 for Conda packages. To do so, set `METAFLOW_CONDA_PREFERRED_FORMAT` to `.conda`. Note that you need
 either `micromamba` or `conda-package-handling` installed for this to work.
 
+### File locking
+Conda (and associates), does not like it when multiple processes tinker with its data at the same time.
+To prevent this from happening, Metaflow uses various lock files. It does its best to clean them up but
+in some circumstances, these files stick around and prevent Metaflow from proceeding. Metaflow will
+print an error message warning you that it is waiting for a certain lock file to be removed
+prior to proceeding.
+
+Removing the file will typically allow Metaflow to proceed. You can also set the amount of time
+Metaflow waits before warning you by setting `METAFLOW_CONDA_LOCK_TIMEOUT` which is currently set
+to 300 seconds (5 minutes).
+
 ## Troubleshooting
 If you run into issues, you can run with `METAFLOW_DEBUG_CONDA=1` to get a more detailed output of
 what is happening. This output can help the Metaflow community figure out the problem.

--- a/metaflow_extensions/netflix_ext/config/mfextinit_netflixext.py
+++ b/metaflow_extensions/netflix_ext/config/mfextinit_netflixext.py
@@ -62,7 +62,7 @@ CONDA_MIXED_DEPENDENCY_RESOLVER = from_conf(
 )
 
 # Timeout trying to acquire the lock to create environments
-CONDA_LOCK_TIMEOUT = from_conf("CONDA_LOCK_TIMEOUT", 3600)
+CONDA_LOCK_TIMEOUT = from_conf("CONDA_LOCK_TIMEOUT", 300)
 
 # Location within CONDA_<DS>ROOT of the packages directory
 CONDA_PACKAGES_DIRNAME = from_conf("ENV_PACKAGES_DIRNAME", "packages")

--- a/metaflow_extensions/netflix_ext/plugins/conda/resolvers/pip_resolver.py
+++ b/metaflow_extensions/netflix_ext/plugins/conda/resolvers/pip_resolver.py
@@ -353,8 +353,8 @@ class PipResolver(Resolver):
                                         "-c",
                                         "import tomli; f = open('%s', mode='rb'); "
                                         "d = tomli.load(f); "
-                                        "print(d.get('poetry', d['tool']['poetry'])['name']); "
-                                        "print(d.get('poetry', d['tool']['poetry'])['version'])"
+                                        "print(d.get('project', d.get('poetry', d['tool']['poetry']))['name']); "
+                                        "print(d.get('project', d.get('poetry', d['tool']['poetry']))['version'])"
                                         % os.path.join(local_path, "pyproject.toml"),
                                     ],
                                     binary=builder_python,
@@ -401,9 +401,9 @@ class PipResolver(Resolver):
                         else:
                             parse_result = parse_explicit_path_pypi(
                                 url,
-                                hash_value=file_hash.split("=")[1]
-                                if file_hash
-                                else None,
+                                hash_value=(
+                                    file_hash.split("=")[1] if file_hash else None
+                                ),
                             )
                             if parse_result.url_format != ".whl":
                                 # This is a source package so we need to build it
@@ -526,9 +526,11 @@ class PipResolver(Resolver):
                                 parse_result.filename,
                                 parse_result.url,
                                 url_format=parse_result.url_format,
-                                hashes={parse_result.url_format: parse_result.hash}
-                                if parse_result.hash
-                                else None,
+                                hashes=(
+                                    {parse_result.url_format: parse_result.hash}
+                                    if parse_result.hash
+                                    else None
+                                ),
                             )
                         )
             if to_build_pkg_info:


### PR DESCRIPTION
This improves:
  - cross platform building when GLIBC is injected (showed up as a pydantic error)
  - issue when using conda with conda-lock
  - building local packages with pyproject.toml files
  - timeout documentation