### PR TITLE
Fix issue with running Metaflow with the runner environment

### DIFF
--- a/metaflow_extensions/netflix_ext/plugins/conda/conda_common_decorator.py
+++ b/metaflow_extensions/netflix_ext/plugins/conda/conda_common_decorator.py
@@ -127,6 +127,7 @@ class StepRequirement(StepRequirementIface):
                 or self.from_pathspec
                 or self.packages
                 or self.sources
+                or self.is_fetch_at_exec
             ):
                 return False
             return None


### PR DESCRIPTION
In some cases, the outside environment would "leak" to the inner execution