### PR TITLE
Support GIT packages through conda-lock

### DIFF
--- a/metaflow_extensions/netflix_ext/plugins/conda/utils.py
+++ b/metaflow_extensions/netflix_ext/plugins/conda/utils.py
@@ -362,8 +362,10 @@ def parse_explicit_url_pypi(url: str) -> ParseExplicitResult:
     #  - the URL (without the hash)
     #  - the format for the URL
     #  - the hash
+
     url_clean, temp_url_hash = url.rsplit("#", 1)
     url_hash: Optional[str] = temp_url_hash
+    
     if url_hash:
         if not url_hash.startswith("sha256="):
             raise CondaException("URL '%s' has a SHA type which is not supported" % url)

--- a/metaflow_extensions/netflix_ext/plugins/conda/utils.py
+++ b/metaflow_extensions/netflix_ext/plugins/conda/utils.py
@@ -365,7 +365,7 @@ def parse_explicit_url_pypi(url: str) -> ParseExplicitResult:
 
     url_clean, temp_url_hash = url.rsplit("#", 1)
     url_hash: Optional[str] = temp_url_hash
-    
+
     if url_hash:
         if not url_hash.startswith("sha256="):
             raise CondaException("URL '%s' has a SHA type which is not supported" % url)


### PR DESCRIPTION
This will now build packages coming from GIT just like in the pure PYPI path.