### PR TITLE
fix: missing key lookup on mamba versions

### DIFF
--- a/metaflow_extensions/netflix_ext/plugins/conda/conda.py
+++ b/metaflow_extensions/netflix_ext/plugins/conda/conda.py
@@ -2049,7 +2049,7 @@ class Conda(object):
                 self.is_non_conda_exec = True
         elif "mamba version" in self._info_no_lock:
             # Mamba 2.0+ has mamba version but no conda version
-            if parse_version(self._info_no_lock) < parse_version("2.0.0"):
+            if parse_version(self._info_no_lock["mamba version"]) < parse_version("2.0.0"):
                 return InvalidEnvironmentException(
                     self._install_message_for_resolver("mamba")
                 )


### PR DESCRIPTION
otherwise we get this:

```python
  File "/usr/lib/python3.13/site-packages/metaflow_extensions/netflix_ext/plugins/conda/conda.py", line 1839, in _ensure_local_conda
    err = self._validate_conda_installation()
  File "/usr/lib/python3.13/site-packages/metaflow_extensions/netflix_ext/plugins/conda/conda.py", line 2052, in _validate_conda_installation
    if parse_version(self._info_no_lock) < parse_version("2.0.0"):
       ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/metaflow/_vendor/packaging/version.py", line 52, in parse
    return Version(version)
  File "/usr/lib/python3.13/site-packages/metaflow/_vendor/packaging/version.py", line 195, in __init__
    match = self._regex.search(version)
TypeError: expected string or bytes-like object, got 'dict'
```