### PR TITLE
fix: add missing access to get mamba version in conda decorator

### DIFF
--- a/metaflow_extensions/netflix_ext/plugins/conda/conda.py
+++ b/metaflow_extensions/netflix_ext/plugins/conda/conda.py
@@ -2049,7 +2049,7 @@ class Conda(object):
                 self.is_non_conda_exec = True
         elif "mamba version" in self._info_no_lock:
             # Mamba 2.0+ has mamba version but no conda version
-            if parse_version(self._info_no_lock) < parse_version("2.0.0"):
+            if parse_version(self._info_no_lock["mamba version"]) < parse_version("2.0.0"):
                 return InvalidEnvironmentException(
                     self._install_message_for_resolver("mamba")
                 )


### PR DESCRIPTION
Seems like a typo that this was forgotten and I stumbled upon this.