### PR TITLE
Make remote command set configurable; support micromamba version key variants

### DIFF
--- a/metaflow_extensions/netflix_ext/config/mfextinit_netflixext.py
+++ b/metaflow_extensions/netflix_ext/config/mfextinit_netflixext.py
@@ -128,7 +128,7 @@ CONDA_DEFAULT_PYPI_SOURCE = from_conf("CONDA_DEFAULT_PYPI_SOURCE", None)
 # value: a tuple/list of username and password
 CONDA_SRCS_AUTH_INFO = from_conf("CONDA_SRCS_AUTH_INFO", {})
 
-CONDA_REMOTE_COMMANDS = from_conf("CONDA_REMOTE_COMMANDS", ("batch", "kubernetes"))
+CONDA_REMOTE_COMMANDS = from_conf("CONDA_REMOTE_COMMANDS", ["batch", "kubernetes"])
 
 # List of system dependencies that are allowed to indicate the system to build on
 CONDA_SYS_DEPENDENCIES = ("__cuda", "__glibc")

--- a/metaflow_extensions/netflix_ext/config/mfextinit_netflixext.py
+++ b/metaflow_extensions/netflix_ext/config/mfextinit_netflixext.py
@@ -128,7 +128,7 @@ CONDA_DEFAULT_PYPI_SOURCE = from_conf("CONDA_DEFAULT_PYPI_SOURCE", None)
 # value: a tuple/list of username and password
 CONDA_SRCS_AUTH_INFO = from_conf("CONDA_SRCS_AUTH_INFO", {})
 
-CONDA_REMOTE_COMMANDS = ("batch", "kubernetes")
+CONDA_REMOTE_COMMANDS = from_conf("CONDA_REMOTE_COMMANDS", ("batch", "kubernetes"))
 
 # List of system dependencies that are allowed to indicate the system to build on
 CONDA_SYS_DEPENDENCIES = ("__cuda", "__glibc")

--- a/metaflow_extensions/netflix_ext/plugins/conda/conda.py
+++ b/metaflow_extensions/netflix_ext/plugins/conda/conda.py
@@ -2097,10 +2097,9 @@ class Conda(object):
                 )
                 del self._bins["pip"]
 
-        if "micromamba version" in self._info_no_lock:
-            if parse_version(self._info_no_lock["micromamba version"]) < parse_version(
-                "1.4.0"
-            ):
+        micromamba_version = self._micromamba_version(self._info_no_lock)
+        if micromamba_version is not None:
+            if parse_version(micromamba_version) < parse_version("1.4.0"):
                 return InvalidEnvironmentException(
                     self._install_message_for_resolver("micromamba")
                 )
@@ -2753,6 +2752,18 @@ class Conda(object):
             )
         else:
             return "Unknown resolver '%s'" % resolver
+
+    @staticmethod
+    def _micromamba_version(info: Mapping[str, Any]) -> Optional[str]:
+        # Some micromamba builds expose platform-qualified keys, e.g.
+        # "micromamba-linux-aarch64 version", instead of "micromamba version".
+        micromamba_version = info.get("micromamba version")
+        if micromamba_version is not None:
+            return cast(str, micromamba_version)
+        for info_key, info_val in info.items():
+            if info_key.startswith("micromamba") and info_key.endswith(" version"):
+                return cast(str, info_val)
+        return None
 
     def _envars_for_conda_exec(self, env_vars: Dict[str, str]):
         def _update_if_not_present(d: Dict[str, str]):

--- a/metaflow_extensions/netflix_ext/plugins/conda/conda_environment.py
+++ b/metaflow_extensions/netflix_ext/plugins/conda/conda_environment.py
@@ -425,6 +425,15 @@ class CondaEnvironment(MetaflowEnvironment):
                 req.merge_update(step_deco)
         return req
 
+    @staticmethod
+    def _remote_step_arch(decorators: List[Any]) -> str:
+        for deco in decorators:
+            if deco.name in CONDA_REMOTE_COMMANDS:
+                target_platform = getattr(deco, "target_platform", None)
+                if isinstance(target_platform, str) and target_platform:
+                    return target_platform
+        return "linux-64"
+
     @classmethod
     def extract_merged_reqs_for_step(
         cls,
@@ -465,7 +474,10 @@ class CondaEnvironment(MetaflowEnvironment):
         if override_arch:
             step_arch = override_arch
         else:
-            step_arch = "linux-64" if step_is_remote else arch_id()
+            if step_is_remote:
+                step_arch = cls._remote_step_arch(resources_deco)
+            else:
+                step_arch = arch_id()
 
         final_req = cls.extract_reqs_for_flow(flow)
         step_req = cls.extract_reqs_for_step(step)

--- a/metaflow_extensions/netflix_ext/plugins/conda/utils.py
+++ b/metaflow_extensions/netflix_ext/plugins/conda/utils.py
@@ -242,9 +242,10 @@ def pypi_tags_from_arch(
     # This is inspired by what pip does:
     # https://github.com/pypa/pip/blob/0442875a68f19b0118b0b88c747bdaf6b24853ba/src/pip/_internal/utils/compatibility_tags.py
     py_version = tuple(map(int, python_version.split(".")[:2]))
-    if arch == "linux-64":
+    if arch in ("linux-64", "linux-aarch64"):
         max_glibc = "_%s" % glibc_version
         platforms = []  # type: List[str]
+        suffix = "x86_64" if arch == "linux-64" else "aarch64"
         for s in (
             "1",
             "2010",
@@ -271,11 +272,11 @@ def pypi_tags_from_arch(
             "_2_37",
             "_2_38",
         ):
-            platforms.append("manylinux%s_x86_64" % s)
+            platforms.append("manylinux%s_%s" % (s, suffix))
             if s == max_glibc:
                 break
 
-        platforms.append("linux_x86_64")
+        platforms.append("linux_%s" % suffix)
     elif arch == "osx-64":
         platforms = mac_platforms((11, 0), "x86_64")
     elif arch == "osx-arm64":

--- a/metaflow_extensions/netflix_ext/plugins/conda/utils.py
+++ b/metaflow_extensions/netflix_ext/plugins/conda/utils.py
@@ -168,12 +168,14 @@ def get_conda_root(datastore_type: str) -> str:
 
 
 def arch_id() -> str:
-    bit = "32"
-    if platform.machine().endswith("64"):
-        bit = "64"
     if platform.system() == "Linux":
+        machine = platform.machine().lower()
+        if machine in ("aarch64", "arm64"):
+            return "linux-aarch64"
+        bit = "64" if machine.endswith("64") else "32"
         return "linux-%s" % bit
     elif platform.system() == "Darwin":
+        bit = "64" if platform.machine().endswith("64") else "32"
         # Support M1 Mac
         if platform.machine() == "arm64":
             return "osx-arm64"


### PR DESCRIPTION
This change does two things:

- makes `CONDA_REMOTE_COMMANDS` configurable via `from_conf(...)` so extensions can override it with their own backends
- handles micromamba `info --json` outputs that use platform-qualified version keys (for example `"micromamba-linux-aarch64 version"`)

Why:
- sandbox/daytona flows need to mark steps as remote for correct target-platform resolution
- newer micromamba outputs may not include `"micromamba version"`, which caused version detection to fall through incorrectly
