### PR TITLE
Fix broken sdist: include VERSION in source distributions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,3 +7,4 @@ source =
 [report]
 omit =
     */toplevel/nflxext_version.py
+    */toplevel/functions_version.py

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/dist
 **/build
 metaflow-functions/metaflow_extensions/nflx/toplevel/functions_version.py
+metaflow-netflixext/metaflow_extensions/nflx/toplevel/nflxext_version.py

--- a/metaflow-functions/MANIFEST.in
+++ b/metaflow-functions/MANIFEST.in
@@ -1,0 +1,2 @@
+include VERSION
+include README.md

--- a/metaflow-functions/metaflow_extensions/nflx/toplevel/functions_version.py
+++ b/metaflow-functions/metaflow_extensions/nflx/toplevel/functions_version.py
@@ -1,1 +1,0 @@
-_ext_version = "0.2.1.dev1"

--- a/metaflow-netflixext/MANIFEST.in
+++ b/metaflow-netflixext/MANIFEST.in
@@ -1,0 +1,2 @@
+include VERSION
+include README.md


### PR DESCRIPTION
## Summary
- Add `MANIFEST.in` to both `metaflow-netflixext` and `metaflow-functions` so the `VERSION` file is included in sdist tarballs
- Add `nflxext_version.py` to `.gitignore` (generated file, `functions_version.py` was already ignored)
- Remove accidentally tracked `functions_version.py` from git

## Problem
The sdist tarballs published to PyPI for v1.3.7 / 0.2.1 are broken — `setup.py` reads from a `VERSION` file that isn't included in the sdist. This causes:
- `pip install --no-binary :all:` to fail with `FileNotFoundError: VERSION`
- conda-forge builds to fail (conda-forge/metaflow-netflixext-feedstock#12)

Wheel installs work fine since the generated `*_version.py` is included in wheels.

## Test plan
- [ ] CI passes
- [ ] After merge, cut v1.3.8 release and verify sdist installs: `pip install --no-binary :all: metaflow-netflixext==1.3.8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)