### PR TITLE
Port parameter scoping tests and fix pre-existing CI failures

### DIFF
--- a/tests/environments/test_env_resolution.py
+++ b/tests/environments/test_env_resolution.py
@@ -87,7 +87,6 @@ EXPECTED_PACKAGES = {
     },
     "simple-conda.yml": {
         "pandas": ">= 1",
-        "pip": "",
         "requests": ">= 2.21",
     },
     "pip-no-hash.txt": {"typing-extensions": "4.15.0"},

--- a/tests/functions/pipeline/test_parameter_scoping.py
+++ b/tests/functions/pipeline/test_parameter_scoping.py
@@ -1,0 +1,57 @@
+import pytest
+from unittest.mock import MagicMock
+
+pytestmark = pytest.mark.no_backend_parametrization
+
+from metaflow import FunctionParameters
+from metaflow_extensions.nflx.plugins.functions.core.function_pipeline import (
+    FunctionPipeline,
+)
+from metaflow_extensions.nflx.plugins.functions.utils import get_type_string
+
+
+class TypedParams(FunctionParameters):
+    increment: int
+    multiplier: int
+
+
+def make_pipeline() -> FunctionPipeline:
+    """Create a bare FunctionPipeline instance without triggering __init__."""
+    return FunctionPipeline.__new__(FunctionPipeline)
+
+
+def make_func_with_schema(parameter_schema) -> MagicMock:
+    """Create a mock function whose spec has the given parameter_schema."""
+    func = MagicMock()
+    func.spec.function.parameter_schema = parameter_schema
+    return func
+
+
+def test_optional_params_passes_pipeline_params_through():
+    """Optional[FunctionParameters] (parameter_schema=None) passes pipeline params through."""
+    pipeline = make_pipeline()
+    pipeline_params = FunctionParameters(increment=10, multiplier=3)
+    func = make_func_with_schema(None)
+
+    result = pipeline._make_func_params(pipeline_params, func)
+    assert result is pipeline_params
+
+
+def test_base_params_passes_pipeline_params_through():
+    """Base FunctionParameters (empty schema) passes pipeline params through."""
+    pipeline = make_pipeline()
+    pipeline_params = FunctionParameters(increment=10, multiplier=3)
+    func = make_func_with_schema({})
+
+    result = pipeline._make_func_params(pipeline_params, func)
+    assert result is pipeline_params
+
+
+def test_typed_params_isinstance():
+    """Typed FunctionParameters subclass returns an instance of that type."""
+    pipeline = make_pipeline()
+    pipeline_params = FunctionParameters(increment=10, multiplier=3)
+    func = make_func_with_schema({"type": get_type_string(TypedParams)})
+
+    result = pipeline._make_func_params(pipeline_params, func)
+    assert isinstance(result, TypedParams)

--- a/tests/functions/ux/flows/function_module.py
+++ b/tests/functions/ux/flows/function_module.py
@@ -1,4 +1,3 @@
-from typing import Optional
 from metaflow import FunctionParameters
 from metaflow_extensions.nflx.plugins.avro_function import avro_function
 from metaflow_extensions.nflx.plugins.json_function import json_function
@@ -6,40 +5,40 @@ from metaflow_extensions.nflx.plugins.json_function import json_function
 
 @avro_function
 def avro_transform_string(
-    data: str, params: Optional[FunctionParameters] = None
+    data: str, params: FunctionParameters = FunctionParameters()
 ) -> str:
     """Simple avro function that transforms a string using pydash"""
     import pydash as _
 
-    suffix = params.suffix if params and hasattr(params, "suffix") else "default"
-    # Use pydash to uppercase the string
+    suffix = params.suffix if hasattr(params, "suffix") else "default"
     return _.upper_case(data).replace(" ", "") + "_" + str(suffix)
 
 
 @avro_function
-def avro_process_dict(data: dict, params: Optional[FunctionParameters] = None) -> dict:
+def avro_process_dict(
+    data: dict, params: FunctionParameters = FunctionParameters()
+) -> dict:
     """Avro function that processes a dict"""
-    multiplier = params.multiplier if params and hasattr(params, "multiplier") else 2
+    multiplier = params.multiplier if hasattr(params, "multiplier") else 2
     return {k: v * multiplier for k, v in data.items() if isinstance(v, (int, float))}
 
 
 @json_function
 def json_transform_list(
-    data: list, params: Optional[FunctionParameters] = None
+    data: list, params: FunctionParameters = FunctionParameters()
 ) -> list:
     """JSON function that filters a list"""
-    threshold = params.threshold if params and hasattr(params, "threshold") else 0
+    threshold = params.threshold if hasattr(params, "threshold") else 0
     return [x for x in data if x > threshold]
 
 
 @json_function
 def json_process_object(
-    data: dict, params: Optional[FunctionParameters] = None
+    data: dict, params: FunctionParameters = FunctionParameters()
 ) -> dict:
     """JSON function that adds a field using pydash"""
     import pydash as _
 
-    # Use pydash to merge the data with new fields
-    increment = params.increment if params and hasattr(params, "increment") else 1
+    increment = params.increment if hasattr(params, "increment") else 1
     result = _.merge({}, data, {"processed": True, "increment": increment})
     return result


### PR DESCRIPTION
## Summary
- Ports pipeline parameter scoping unit tests from mli-metaflow-custom PR #1766 (missed during source-only port in c7cda7d)
- Fixes conda resolver test: removes `pip` from `simple-conda.yml` expected packages — conda resolver no longer lists it as an explicit package
- Fixes functions UX test regression from PR #69: changes `Optional[FunctionParameters] = None` to `FunctionParameters = FunctionParameters()` in test functions that access task artifacts (`params.suffix`, `params.increment`), since PR #69 made `Optional[FunctionParameters]` signal "no artifacts needed"

## Test plan
- [x] `test_parameter_scoping.py` — 3 tests pass (pipeline param scoping)
- [x] `test_functions_simple_avro_json` — passes (was failing since PR #69)
- [x] `test_resolve_environment_from_file[simple-conda.yml]` — passes (conda resolver)
- [x] `test_resolve_environment_no_crash[simple-conda.yml]` — passes (conda resolver)
- [x] All 18 previously-failing CI checks now green

🤖 Generated with [Claude Code](https://claude.com/claude-code)