### PR TITLE
Fix _LazyDebug returning _noop for dunder attributes

### DIFF
--- a/metaflow-functions/metaflow_extensions/nflx/plugins/functions/debug.py
+++ b/metaflow-functions/metaflow_extensions/nflx/plugins/functions/debug.py
@@ -28,17 +28,15 @@ class _LazyDebug:
         return resolved
 
     def __getattr__(self, name):
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
         resolved = self._resolve()
-        # Use object.__getattribute__ to avoid recursion if metaflow's debug
-        # doesn't have the attribute registered yet (e.g. during init)
         try:
             val = resolved.__dict__.get(name)
             if val is not None:
                 return val
         except AttributeError:
             pass
-        # Attribute not registered yet - return noop to avoid recursion
-        # in metaflow's Debug.__getattr__ which calls getattr(self, name)
         return _noop
 
 


### PR DESCRIPTION
## Summary

- Fix `_LazyDebug.__getattr__` in `metaflow-functions` to raise `AttributeError` for dunder attributes (`__name__`, `__module__`, etc.) instead of returning `_noop`
- This caused the metaflow stub generator to emit invalid Python syntax in the generated `function.pyi`, breaking all stubs tests in `mli-metaflow-custom` releases

## Root Cause

`_LazyDebug` proxies attribute access to metaflow's debug object, falling back to `_noop` for unregistered attributes. But it also returned `_noop` for dunder attributes like `__name__`. The stub generator calls `getattr(obj, "__name__")` to determine import names, which returned the `_noop` function object, producing:

```python
from ..debug import <function _noop at 0x102cd4a60> as debug
```

## Test plan

- [ ] Verify stubs generate without syntax errors: `python -c "from metaflow.cmd.develop.stub_generator import StubGenerator; StubGenerator('./stubs').write_out()"`
- [ ] Verify `debug.functions_exec` still works as a noop before metaflow init

🤖 Generated with [Claude Code](https://claude.com/claude-code)