### PR TITLE
fix: use f.write for _env_path to avoid json.dump quoting

### DIFF
--- a/metaflow-netflixext/metaflow_extensions/nflx/plugins/conda/remote_bootstrap.py
+++ b/metaflow-netflixext/metaflow_extensions/nflx/plugins/conda/remote_bootstrap.py
@@ -80,7 +80,7 @@ def bootstrap_environment(
     with open("_env_path", mode="w", encoding="utf-8") as f:
         if python_bin is None:
             raise RuntimeError("Environment was not created properly")
-        json.dump(os.path.dirname(os.path.dirname(python_bin)), f)
+        f.write(os.path.dirname(os.path.dirname(python_bin)))
 
 
 def setup_conda_manifest():


### PR DESCRIPTION
## Summary

`json.dump` wraps the path string in JSON double quotes when writing `_env_path`. When the shell later expands `$(cat _env_path)/lib`, the literal quote characters produce an invalid path.

**Before:** `"${path}"` (with JSON quotes)
**After:** `${path}` (bare string)

This is a one-line fix: replace `json.dump(path, f)` with `f.write(path)`.

## Test plan
- [ ] Verify `_env_path` file contains a bare path with no surrounding quotes after environment bootstrap.
- [ ] Confirm `LD_LIBRARY_PATH=$(cat _env_path)/lib` resolves correctly in a remote task.