### PR TITLE
Port resilience fixes from internal master (PRs #1850, #1846, #1844)

### DIFF
--- a/metaflow-netflixext/metaflow_extensions/nflx/plugins/conda/conda_environment.py
+++ b/metaflow-netflixext/metaflow_extensions/nflx/plugins/conda/conda_environment.py
@@ -210,11 +210,32 @@ class CondaEnvironment(MetaflowEnvironment):
                     datastore_type,
                 ),
                 "export _METAFLOW_CONDA_ENV=$(cat _env_id)",
-                "export PYTHONPATH=$(pwd)/_escape_trampolines:$(printenv PYTHONPATH)",
-                # NOTE: Assumes here that remote nodes are Linux
-                # We could remove the if but keeping things clean and not transforming
-                # an unset value into a set value.
-                "if [[ -n $(printenv LD_LIBRARY_PATH) ]]; then "
+                # Sanitize host-inherited PYTHONPATH so the conda env uses its
+                # own stdlib, not the host's. Specifically, bare Python lib
+                # directories (e.g. /usr/lib/python3.10, /apps/.../python3.10)
+                # contain a platform.py whose _sys_version regex predates the
+                # conda-forge "| packaged by conda-forge |" format, causing
+                # platform.python_implementation() to raise ValueError.
+                #
+                # Strategy: keep the first entry (bundled metaflow, prepended
+                # by metaflow_environment.get_package_commands) and any
+                # site-packages / dist-packages entries (which provide runtime
+                # tools like scheduler_tool that must remain importable).
+                # Drop bare stdlib dirs that would shadow the conda stdlib.
+                #
+                # Save the original to MF_ORIG_PYTHONPATH so env-escape
+                # trampolines can restore it for sub-shells.
+                "if printenv PYTHONPATH >/dev/null 2>&1; then "
+                "export MF_ORIG_PYTHONPATH=$(printenv PYTHONPATH); fi",
+                "export PYTHONPATH=$(pwd)/_escape_trampolines:"
+                "$(printenv PYTHONPATH | tr ':' '\\n' | "
+                "awk 'NR==1 || /site-packages/ || /dist-packages/' | "
+                "paste -sd:)",
+                # NOTE: Assumes here that remote nodes are Linux. The host
+                # LD_LIBRARY_PATH tail is preserved deliberately so that OS
+                # libraries (e.g. accelerator drivers) the conda env may link
+                # against remain discoverable.
+                "if printenv LD_LIBRARY_PATH >/dev/null 2>&1; then "
                 "export MF_ORIG_LD_LIBRARY_PATH=$(printenv LD_LIBRARY_PATH); "
                 "export LD_LIBRARY_PATH=$(cat _env_path)/lib:$(printenv LD_LIBRARY_PATH); else "
                 "export LD_LIBRARY_PATH=$(cat _env_path)/lib; fi",

--- a/metaflow-netflixext/metaflow_extensions/nflx/plugins/coverage/setup_coverage.py
+++ b/metaflow-netflixext/metaflow_extensions/nflx/plugins/coverage/setup_coverage.py
@@ -66,11 +66,14 @@ def setup_sitecustomize(python_binary: str):
         f"os.environ['COVERAGE_PROCESS_START'] = os.environ.get('COVERAGE_PROCESS_START') or os.path.join(site_packages_dir, '.coveragerc')",
         f"os.environ['COVERAGE_RCFILE'] = os.environ.get('COVERAGE_RCFILE') or os.path.join(site_packages_dir, '.coveragerc')",
         f"os.environ['METAFLOW_COVERAGE_S3_PATH'] = os.environ.get('METAFLOW_COVERAGE_S3_PATH') or '{os.environ['METAFLOW_COVERAGE_S3_PATH']}'",
-        "import coverage",
-        "coverage.process_startup()",
-        "coverage_context = os.environ.get('METAFLOW_COVERAGE_CONTEXT')",
-        "if coverage_context and coverage.Coverage.current():",
-        "    coverage.Coverage.current().switch_context(coverage_context)",
+        "try:",
+        "    import coverage",
+        "    coverage.process_startup()",
+        "    coverage_context = os.environ.get('METAFLOW_COVERAGE_CONTEXT')",
+        "    if coverage_context and coverage.Coverage.current():",
+        "        coverage.Coverage.current().switch_context(coverage_context)",
+        "except Exception as _cov_err:",
+        "    import sys; print(f'Warning: coverage instrumentation skipped: {_cov_err}', file=sys.stderr)",
     ]
     if not os.path.exists(sitecustomize_file):
         with open(sitecustomize_file, "w") as target_file:

--- a/metaflow-netflixext/metaflow_extensions/nflx/plugins/coverage/setup_coverage.py
+++ b/metaflow-netflixext/metaflow_extensions/nflx/plugins/coverage/setup_coverage.py
@@ -104,8 +104,14 @@ def setup_coverage(sh_python: Union[str, "sh.Command"]):
     for python_binary in python_binaries:
         if not python_binary or not which(python_binary):
             continue
-        maybe_install_coverage(python_binary)
-        setup_sitecustomize(python_binary)
+        try:
+            maybe_install_coverage(python_binary)
+            setup_sitecustomize(python_binary)
+        except Exception as e:
+            print(
+                f"Warning: coverage setup failed for {python_binary}: {e}",
+                file=sys.stderr,
+            )
 
 
 if __name__ == "__main__":

--- a/metaflow-netflixext/metaflow_extensions/nflx/plugins/coverage/upload_coverage_files.py
+++ b/metaflow-netflixext/metaflow_extensions/nflx/plugins/coverage/upload_coverage_files.py
@@ -1,4 +1,13 @@
-import coverage
+try:
+    import coverage
+except Exception as _e:
+    import sys
+
+    print(
+        f"Warning: coverage upload skipped — could not import coverage: {_e}",
+        file=sys.stderr,
+    )
+    sys.exit(0)
 import glob
 import gzip
 import hashlib


### PR DESCRIPTION
## Summary

Three resilience fixes that landed on the Netflix internal MDM master after the last OSS sync but weren't ported here.

| OSS commit | Internal PR | Files | What it does |
|---|---|---|---|
| Port #1850 | mdm#1850 | `conda/conda_environment.py` | Sanitize host PYTHONPATH in conda remote bootstrap so the host's `platform.py` doesn't shadow the conda env's. |
| Port #1846 | mdm#1846 | `coverage/setup_coverage.py` | Wrap per-binary `maybe_install_coverage` + `setup_sitecustomize` in try/except so one broken interpreter doesn't abort coverage setup for the rest. |
| Port #1844 | mdm#1844 | `coverage/setup_coverage.py`, `coverage/upload_coverage_files.py` | Skip coverage gracefully when the `coverage` module itself is broken/missing (sys.exit(0) instead of crashing the upload, try/except around `import coverage` in injected sitecustomize code). |

Internal PR #1842 (`f.write` for `_env_path`) is intentionally NOT included here — already covered by #81.

## Test plan
- [ ] `import` the three modified modules in a fresh venv to confirm they parse and load.
- [ ] Run the netflixext test suite locally / in CI.
- [ ] Spot-check a remote conda bootstrap on Linux to confirm the new PYTHONPATH filter doesn't drop entries that legit user code depends on (only bare stdlib dirs).
- [ ] Trigger a coverage run with a deliberately-broken interpreter on the binary set to confirm the try/except handles it without aborting coverage setup for the other binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)