### PR TITLE
docs: add runnable examples directory

### DIFF
--- a/examples/01_basic_conda/README.md
+++ b/examples/01_basic_conda/README.md
@@ -12,7 +12,7 @@ python flow.py --environment=conda run
 
 ## What to expect
 
-- `start` runs in an environment with `pandas==1.4.0`.
-- `end` runs in an environment with `pandas==1.5.0`.
+- `start` runs in an environment with `pandas==2.1.4`.
+- `end` runs in an environment with `pandas==2.2.2`.
 - The first run resolves both environments (takes ~30s); subsequent runs reuse
   the cached environments.

--- a/examples/01_basic_conda/README.md
+++ b/examples/01_basic_conda/README.md
@@ -1,0 +1,18 @@
+# 01 — Basic `@conda`
+
+The `@conda` decorator pins Conda packages on a per-step basis. Each step gets
+its own environment, so different steps can use different versions of the same
+library.
+
+## Run
+
+```bash
+python flow.py --environment=conda run
+```
+
+## What to expect
+
+- `start` runs in an environment with `pandas==1.4.0`.
+- `end` runs in an environment with `pandas==1.5.0`.
+- The first run resolves both environments (takes ~30s); subsequent runs reuse
+  the cached environments.

--- a/examples/01_basic_conda/flow.py
+++ b/examples/01_basic_conda/flow.py
@@ -4,21 +4,21 @@ from metaflow import FlowSpec, conda, step
 class BasicCondaFlow(FlowSpec):
     """Two steps, each pinning a different pandas version via @conda."""
 
-    @conda(libraries={"pandas": "1.4.0"}, python=">=3.9,<3.10")
+    @conda(libraries={"pandas": "2.1.4"}, python=">=3.10,<3.11")
     @step
     def start(self):
         import pandas as pd
 
-        assert pd.__version__ == "1.4.0"
+        assert pd.__version__ == "2.1.4"
         print("start: pandas %s" % pd.__version__)
         self.next(self.end)
 
-    @conda(libraries={"pandas": "1.5.0"}, python=">=3.9,<3.10")
+    @conda(libraries={"pandas": "2.2.2"}, python=">=3.10,<3.11")
     @step
     def end(self):
         import pandas as pd
 
-        assert pd.__version__ == "1.5.0"
+        assert pd.__version__ == "2.2.2"
         print("end: pandas %s" % pd.__version__)
 
 

--- a/examples/01_basic_conda/flow.py
+++ b/examples/01_basic_conda/flow.py
@@ -1,0 +1,26 @@
+from metaflow import FlowSpec, conda, step
+
+
+class BasicCondaFlow(FlowSpec):
+    """Two steps, each pinning a different pandas version via @conda."""
+
+    @conda(libraries={"pandas": "1.4.0"}, python=">=3.9,<3.10")
+    @step
+    def start(self):
+        import pandas as pd
+
+        assert pd.__version__ == "1.4.0"
+        print("start: pandas %s" % pd.__version__)
+        self.next(self.end)
+
+    @conda(libraries={"pandas": "1.5.0"}, python=">=3.9,<3.10")
+    @step
+    def end(self):
+        import pandas as pd
+
+        assert pd.__version__ == "1.5.0"
+        print("end: pandas %s" % pd.__version__)
+
+
+if __name__ == "__main__":
+    BasicCondaFlow()

--- a/examples/02_pypi/README.md
+++ b/examples/02_pypi/README.md
@@ -12,8 +12,8 @@ python flow.py --environment=conda run
 
 ## What to expect
 
-- `start` runs in an environment with `pandas==1.4.0` installed from PyPI.
-- `end` runs in an environment with `pandas==1.5.0` installed from PyPI.
+- `start` runs in an environment with `pandas==2.1.4` installed from PyPI.
+- `end` runs in an environment with `pandas==2.2.2` installed from PyPI.
 
 ## When to choose `@pypi` over `@conda`
 

--- a/examples/02_pypi/README.md
+++ b/examples/02_pypi/README.md
@@ -1,0 +1,25 @@
+# 02 — Basic `@pypi`
+
+The `@pypi` decorator resolves PyPI packages instead of Conda packages. Use
+this when you want plain `pip`-style dependencies (often faster to resolve, and
+useful when a wheel exists on PyPI but not on conda-forge).
+
+## Run
+
+```bash
+python flow.py --environment=conda run
+```
+
+## What to expect
+
+- `start` runs in an environment with `pandas==1.4.0` installed from PyPI.
+- `end` runs in an environment with `pandas==1.5.0` installed from PyPI.
+
+## When to choose `@pypi` over `@conda`
+
+- You only need pure-Python packages (or packages with manylinux wheels).
+- The package you need only exists on PyPI.
+- You want a smaller, faster-to-resolve environment.
+
+Use `@conda` when you need non-Python libraries (e.g. `cuda`, `gdal`, system
+libraries) that conda-forge ships alongside Python bindings.

--- a/examples/02_pypi/flow.py
+++ b/examples/02_pypi/flow.py
@@ -4,21 +4,21 @@ from metaflow import FlowSpec, pypi, step
 class PypiFlow(FlowSpec):
     """Two steps, each pinning a different pandas version via @pypi."""
 
-    @pypi(packages={"pandas": "1.4.0"}, python=">=3.9,<3.10")
+    @pypi(packages={"pandas": "2.1.4"}, python=">=3.10,<3.11")
     @step
     def start(self):
         import pandas as pd
 
-        assert pd.__version__ == "1.4.0"
+        assert pd.__version__ == "2.1.4"
         print("start: pandas %s" % pd.__version__)
         self.next(self.end)
 
-    @pypi(packages={"pandas": "1.5.0"}, python=">=3.9,<3.10")
+    @pypi(packages={"pandas": "2.2.2"}, python=">=3.10,<3.11")
     @step
     def end(self):
         import pandas as pd
 
-        assert pd.__version__ == "1.5.0"
+        assert pd.__version__ == "2.2.2"
         print("end: pandas %s" % pd.__version__)
 
 

--- a/examples/02_pypi/flow.py
+++ b/examples/02_pypi/flow.py
@@ -1,0 +1,26 @@
+from metaflow import FlowSpec, pypi, step
+
+
+class PypiFlow(FlowSpec):
+    """Two steps, each pinning a different pandas version via @pypi."""
+
+    @pypi(packages={"pandas": "1.4.0"}, python=">=3.9,<3.10")
+    @step
+    def start(self):
+        import pandas as pd
+
+        assert pd.__version__ == "1.4.0"
+        print("start: pandas %s" % pd.__version__)
+        self.next(self.end)
+
+    @pypi(packages={"pandas": "1.5.0"}, python=">=3.9,<3.10")
+    @step
+    def end(self):
+        import pandas as pd
+
+        assert pd.__version__ == "1.5.0"
+        print("end: pandas %s" % pd.__version__)
+
+
+if __name__ == "__main__":
+    PypiFlow()

--- a/examples/03_mixed_conda_pypi/README.md
+++ b/examples/03_mixed_conda_pypi/README.md
@@ -3,7 +3,7 @@
 This example shows three things in one flow:
 
 1. **`@conda_base`** at the flow level provides default packages
-   (`numpy==1.24.4`, `python>=3.10,<3.11`) that apply to every step unless
+   (`numpy==1.26.4`, `python>=3.10,<3.11`) that apply to every step unless
    overridden.
 2. **`@conda`** at the step level *adds* to the base (gets `numpy` + `scipy`).
 3. **`@pypi`** at the step level *replaces* conda with PyPI for that step

--- a/examples/03_mixed_conda_pypi/README.md
+++ b/examples/03_mixed_conda_pypi/README.md
@@ -1,0 +1,25 @@
+# 03 — Mixed `@conda` + `@pypi` with `@conda_base`
+
+This example shows three things in one flow:
+
+1. **`@conda_base`** at the flow level provides default packages
+   (`numpy==1.24.4`, `python>=3.10,<3.11`) that apply to every step unless
+   overridden.
+2. **`@conda`** at the step level *adds* to the base (gets `numpy` + `scipy`).
+3. **`@pypi`** at the step level *replaces* conda with PyPI for that step
+   (gets `requests` from PyPI, no numpy).
+
+## Run
+
+```bash
+python flow.py --environment=conda run
+```
+
+## What to expect
+
+- `start` uses the `@conda_base` env (numpy only).
+- `conda_step` extends with scipy.
+- `pypi_step` uses a separate PyPI-only env (requests).
+- `join` and `end` inherit the base.
+
+Each unique environment is resolved once and cached.

--- a/examples/03_mixed_conda_pypi/flow.py
+++ b/examples/03_mixed_conda_pypi/flow.py
@@ -1,7 +1,7 @@
 from metaflow import FlowSpec, conda, conda_base, pypi, step
 
 
-@conda_base(libraries={"numpy": "1.24.4"}, python=">=3.10,<3.11")
+@conda_base(libraries={"numpy": "1.26.4"}, python=">=3.10,<3.11")
 class MixedFlow(FlowSpec):
     """
     `@conda_base` sets defaults for the whole flow (numpy + python here).
@@ -12,7 +12,7 @@ class MixedFlow(FlowSpec):
     def start(self):
         import numpy as np
 
-        assert np.__version__ == "1.24.4"
+        assert np.__version__ == "1.26.4"
         print("start: numpy %s (from @conda_base)" % np.__version__)
         self.next(self.conda_step, self.pypi_step)
 

--- a/examples/03_mixed_conda_pypi/flow.py
+++ b/examples/03_mixed_conda_pypi/flow.py
@@ -1,0 +1,46 @@
+from metaflow import FlowSpec, conda, conda_base, pypi, step
+
+
+@conda_base(libraries={"numpy": "1.24.4"}, python=">=3.10,<3.11")
+class MixedFlow(FlowSpec):
+    """
+    `@conda_base` sets defaults for the whole flow (numpy + python here).
+    Individual steps can extend with `@conda` or override with `@pypi`.
+    """
+
+    @step
+    def start(self):
+        import numpy as np
+
+        assert np.__version__ == "1.24.4"
+        print("start: numpy %s (from @conda_base)" % np.__version__)
+        self.next(self.conda_step, self.pypi_step)
+
+    @conda(libraries={"scipy": "1.11.4"})
+    @step
+    def conda_step(self):
+        import numpy as np
+        import scipy
+
+        print("conda_step: numpy=%s scipy=%s" % (np.__version__, scipy.__version__))
+        self.next(self.join)
+
+    @pypi(packages={"requests": "2.31.0"})
+    @step
+    def pypi_step(self):
+        import requests
+
+        print("pypi_step: requests=%s" % requests.__version__)
+        self.next(self.join)
+
+    @step
+    def join(self, inputs):
+        self.next(self.end)
+
+    @step
+    def end(self):
+        print("done")
+
+
+if __name__ == "__main__":
+    MixedFlow()

--- a/examples/04_from_yml_file/README.md
+++ b/examples/04_from_yml_file/README.md
@@ -2,7 +2,8 @@
 
 Use the `metaflow environment` CLI to resolve dependencies described in an
 `environment.yml`. The resolved environment gets cached and can be referenced
-by alias from any flow (see [example 06](../06_named_environment/)).
+by alias from any flow with `@named_env`—see [example 06](../06_named_environment/)
+for a full walkthrough of that pattern (using its own alias).
 
 The `environment.yml` here mixes Conda packages (numpy, pandas, python) with
 PyPI packages (requests via the `pip:` section).

--- a/examples/04_from_yml_file/README.md
+++ b/examples/04_from_yml_file/README.md
@@ -1,0 +1,56 @@
+# 04 — Resolve from `environment.yml`
+
+Use the `metaflow environment` CLI to resolve dependencies described in an
+`environment.yml`. The resolved environment gets cached and can be referenced
+by alias from any flow (see [example 06](../06_named_environment/)).
+
+The `environment.yml` here mixes Conda packages (numpy, pandas, python) with
+PyPI packages (requests via the `pip:` section).
+
+## Resolve and alias
+
+```bash
+metaflow --environment=conda environment resolve \
+    --alias examples/yml_demo \
+    -f environment.yml
+```
+
+## Inspect the resolved environment
+
+```bash
+metaflow --environment=conda environment show examples/yml_demo
+```
+
+## Use it in a flow
+
+Once aliased, reference it with `@named_env`:
+
+```python
+from metaflow import FlowSpec, named_env, step
+
+class YmlFlow(FlowSpec):
+    @named_env(name="examples/yml_demo")
+    @step
+    def start(self):
+        import pandas, requests
+        print(pandas.__version__, requests.__version__)
+        self.next(self.end)
+
+    @named_env(name="examples/yml_demo")
+    @step
+    def end(self):
+        pass
+
+if __name__ == "__main__":
+    YmlFlow()
+```
+
+## Supported `environment.yml` keys
+
+- `channels:` — Conda channels
+- `dependencies:` — top-level Conda packages and a nested `- pip:` list for
+  PyPI packages
+- `pypi-indices:` — additional PyPI sources
+- `sys:` — system / virtual packages (e.g. `__cuda`, `__glibc`)
+
+See [`docs/conda.md`](../../docs/conda.md) for the full set of options.

--- a/examples/04_from_yml_file/environment.yml
+++ b/examples/04_from_yml_file/environment.yml
@@ -2,7 +2,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.10
-  - numpy=1.24.4
+  - numpy=1.26.4
   - pandas=2.0.3
   - pip:
       - requests==2.31.0

--- a/examples/04_from_yml_file/environment.yml
+++ b/examples/04_from_yml_file/environment.yml
@@ -1,0 +1,8 @@
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10
+  - numpy=1.24.4
+  - pandas=2.0.3
+  - pip:
+      - requests==2.31.0

--- a/examples/05_from_requirements_txt/README.md
+++ b/examples/05_from_requirements_txt/README.md
@@ -1,0 +1,53 @@
+# 05 — Resolve from `requirements.txt`
+
+The extension extends pip's `requirements.txt` format with `--conda-pkg`, which
+lets you specify non-Python Conda packages alongside ordinary PyPI dependencies.
+This is useful when most of your stack is PyPI but you still need system
+libraries that conda-forge provides.
+
+## Resolve and alias
+
+```bash
+metaflow --environment=conda environment resolve \
+    --python ">=3.10,<3.11" \
+    --alias examples/req_demo \
+    -r requirements.txt
+```
+
+## Use it in a flow
+
+```python
+from metaflow import FlowSpec, named_env, step
+
+class ReqFlow(FlowSpec):
+    @named_env(name="examples/req_demo")
+    @step
+    def start(self):
+        import requests, pandas
+        print(requests.__version__, pandas.__version__)
+        self.next(self.end)
+
+    @named_env(name="examples/req_demo")
+    @step
+    def end(self):
+        pass
+
+if __name__ == "__main__":
+    ReqFlow()
+```
+
+## Supported `requirements.txt` options
+
+In addition to ordinary requirement specifiers:
+
+- `--extra-index-url <url>` — additional PyPI source
+- `--pre` — allow pre-releases
+- `--no-index` — disable the default PyPI index
+- `-f` / `--find-links <url>` — additional wheel-finding source
+- `--trusted-host <host>` — trust an HTTPS host
+- `--conda-pkg <pkg>` — **extension**: include a non-Python Conda package
+
+Not supported: constraints files (`-c`) and environment markers.
+
+See [`docs/conda.md`](../../docs/conda.md) for restrictions on Git/URL/local
+requirements when resolving across architectures.

--- a/examples/05_from_requirements_txt/requirements.txt
+++ b/examples/05_from_requirements_txt/requirements.txt
@@ -1,0 +1,10 @@
+# Standard PyPI packages
+requests==2.31.0
+pandas==2.0.3
+
+# Non-Python Conda packages (extension to standard requirements.txt format).
+# These are pulled from Conda even though everything else here is PyPI.
+--conda-pkg openssl
+
+# Additional PyPI index (standard pip option)
+# --extra-index-url https://pypi.example.com/simple

--- a/examples/06_named_environment/README.md
+++ b/examples/06_named_environment/README.md
@@ -1,0 +1,61 @@
+# 06 — Named environments with `@named_env`
+
+Named environments let you resolve once and reuse across many flows. Resolve a
+set of dependencies, give it an alias, then reference the alias from any flow
+with `@named_env`.
+
+This pattern is useful for:
+
+- Sharing a reproducible environment across a team.
+- Pinning an environment for the life of a project, decoupled from any single
+  flow file.
+- Building an environment ahead of time so flow runs don't pay the resolve
+  cost.
+
+## 1. Resolve and alias
+
+```bash
+metaflow --environment=conda environment resolve \
+    --python ">=3.10,<3.11" \
+    --alias examples/named_demo \
+    --conda-pkg "numpy==1.24.4"
+```
+
+Or, equivalently, from a yaml file:
+
+```bash
+cat > env.yml <<EOF
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10
+  - numpy=1.24.4
+EOF
+
+metaflow --environment=conda environment resolve \
+    --alias examples/named_demo \
+    -f env.yml
+```
+
+## 2. Inspect
+
+```bash
+metaflow --environment=conda environment show examples/named_demo
+```
+
+## 3. Use in a flow
+
+```bash
+python flow.py --environment=conda run
+```
+
+## Alias format
+
+Aliases use slash-separated namespaces with an optional `:tag` for versions:
+
+```
+team/project/environment_name:v1
+```
+
+See [`docs/conda.md` § Named environments](../../docs/conda.md#named-environments)
+for sharing, mutability, and pathspec equivalents.

--- a/examples/06_named_environment/README.md
+++ b/examples/06_named_environment/README.md
@@ -18,7 +18,7 @@ This pattern is useful for:
 metaflow --environment=conda environment resolve \
     --python ">=3.10,<3.11" \
     --alias examples/named_demo \
-    --conda-pkg "numpy==1.24.4"
+    --conda-pkg "numpy==1.26.4"
 ```
 
 Or, equivalently, from a yaml file:
@@ -29,7 +29,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.10
-  - numpy=1.24.4
+  - numpy=1.26.4
 EOF
 
 metaflow --environment=conda environment resolve \

--- a/examples/06_named_environment/flow.py
+++ b/examples/06_named_environment/flow.py
@@ -1,0 +1,27 @@
+from metaflow import FlowSpec, named_env, step
+
+
+class NamedEnvFlow(FlowSpec):
+    """
+    Reference a previously resolved + aliased environment by name. The same
+    alias is used for both steps so they share one cached environment.
+    """
+
+    @named_env(name="examples/named_demo")
+    @step
+    def start(self):
+        import numpy as np
+
+        print("start: numpy %s" % np.__version__)
+        self.next(self.end)
+
+    @named_env(name="examples/named_demo")
+    @step
+    def end(self):
+        import numpy as np
+
+        print("end: numpy %s" % np.__version__)
+
+
+if __name__ == "__main__":
+    NamedEnvFlow()

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,8 +1,10 @@
 # Examples
 
 Self-contained runnable examples demonstrating common metaflow-netflixext use
-cases. Each directory contains a flow and any auxiliary files (requirements,
-environment yaml) needed to run it.
+cases. Examples 01–03 and 06 each contain a runnable `flow.py`. Examples 04
+and 05 demonstrate CLI-based environment resolution; their directories contain
+the input file (`environment.yml` / `requirements.txt`) and a README with a
+sample flow you can copy and run.
 
 Every example assumes you have `metaflow` and `metaflow-netflixext` installed,
 and uses `--environment=conda` to activate the extension's environment

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,24 @@
+# Examples
+
+Self-contained runnable examples demonstrating common metaflow-netflixext use
+cases. Each directory contains a flow and any auxiliary files (requirements,
+environment yaml) needed to run it.
+
+Every example assumes you have `metaflow` and `metaflow-netflixext` installed,
+and uses `--environment=conda` to activate the extension's environment
+management.
+
+```bash
+pip install metaflow metaflow-netflixext
+```
+
+| # | Example | What it shows |
+|---|---|---|
+| 01 | [`01_basic_conda/`](01_basic_conda/) | Per-step `@conda` decorator with different package versions per step |
+| 02 | [`02_pypi/`](02_pypi/) | Per-step `@pypi` decorator (PyPI packages instead of Conda) |
+| 03 | [`03_mixed_conda_pypi/`](03_mixed_conda_pypi/) | Mixing `@conda` and `@pypi` in the same flow, and `@conda_base` defaults |
+| 04 | [`04_from_yml_file/`](04_from_yml_file/) | Resolving an environment from `environment.yml` |
+| 05 | [`05_from_requirements_txt/`](05_from_requirements_txt/) | Resolving an environment from `requirements.txt` (including `--conda-pkg`) |
+| 06 | [`06_named_environment/`](06_named_environment/) | Resolving a named/aliased environment and reusing it with `@named_env` |
+
+For the full reference, see [`docs/conda.md`](../docs/conda.md).


### PR DESCRIPTION
## Summary

Adds an `examples/` directory with six self-contained runnable examples covering the main use cases documented in `docs/conda.md`:

| # | What it shows |
|---|---|
| 01 | per-step `@conda` with version pinning |
| 02 | per-step `@pypi` |
| 03 | `@conda_base` + `@conda` + `@pypi` in one flow |
| 04 | resolve from `environment.yml` |
| 05 | resolve from `requirements.txt` (including `--conda-pkg`) |
| 06 | resolve once, reuse with `@named_env` |

Each example has a flow (or input file) plus a README with the exact command to run and what to expect. A top-level `examples/README.md` indexes them.

Closes #10.

## Test plan

- [ ] `python flow.py --environment=conda run` works for each of `01`, `02`, `03`, `06`
- [ ] `metaflow --environment=conda environment resolve -f environment.yml` works for `04`
- [ ] `metaflow --environment=conda environment resolve -r requirements.txt` works for `05`

🤖 Generated with [Claude Code](https://claude.com/claude-code)