### PR TITLE
chore: declare contents: read on test and test-functions workflows

### DIFF
--- a/.github/workflows/test-functions.yml
+++ b/.github/workflows/test-functions.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   unit:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
test-functions.yml and test.yml are both pure CI test runs that checkout the repo and run pytest matrices. python-publish.yml already declares its own (more permissive) permissions; matching the same workflow-level pattern with read-only scope here.