### PR TITLE
Port missing internal PRs #1749, #1785, #1886, #1915 to OSS

### DIFF
--- a/metaflow-netflixext/metaflow_extensions/nflx/plugins/conda/conda_flow_decorator.py
+++ b/metaflow-netflixext/metaflow_extensions/nflx/plugins/conda/conda_flow_decorator.py
@@ -61,7 +61,7 @@ class CondaRequirementFlowDecorator(
     channels : List[str], default []
         Additional channels to search
     python : str, optional, default None
-        Version of Python to use, e.g. '3.7.4'. If not specified, the current version
+        Version of Python to use, e.g. '3.10.4'. If not specified, the current version
         will be used.
     disabled : bool, default False
         If set to True, uses the external environment.
@@ -138,7 +138,7 @@ class PypiRequirementFlowDecorator(
         Extra arguments to pass to the resolver. For example "pre" to include
         pre-release packages.
     python : str, optional, default None
-        Version of Python to use, e.g. '3.7.4'. If not specified, the current python
+        Version of Python to use, e.g. '3.10.4'. If not specified, the current python
         version will be used.
     disabled : bool, default False
         If set to True, uses the external environment.
@@ -266,7 +266,7 @@ class PipRequirementFlowDecorator(PypiRequirementFlowDecorator):
     extra_indices : List[str], default []
         Additional sources to search for
     python : str, optional, default None
-        Version of Python to use, e.g. '3.7.4'. If not specified, the current python
+        Version of Python to use, e.g. '3.10.4'. If not specified, the current python
         version will be used.
     fetch_at_exec : bool, default False
         DEPRECATED -- use `@named_env(name=)` instead.

--- a/metaflow-netflixext/metaflow_extensions/nflx/plugins/conda/conda_flow_mutator.py
+++ b/metaflow-netflixext/metaflow_extensions/nflx/plugins/conda/conda_flow_mutator.py
@@ -524,6 +524,8 @@ class ResolvedReqFlowDecorator(ResolvedEnvironmentBaseFlowMutator):
                 "pip",
                 "compile",
                 requirements_txt_path,
+                "--index-strategy",
+                "unsafe-best-match",  # Treat all indices equally
                 "--output-file",
                 temp_path,
             ],

--- a/metaflow-netflixext/metaflow_extensions/nflx/plugins/conda/conda_flow_mutator.py
+++ b/metaflow-netflixext/metaflow_extensions/nflx/plugins/conda/conda_flow_mutator.py
@@ -525,7 +525,12 @@ class ResolvedReqFlowDecorator(ResolvedEnvironmentBaseFlowMutator):
                 "compile",
                 requirements_txt_path,
                 "--index-strategy",
-                "unsafe-best-match",  # Treat all indices equally
+                # With the default "first-index" strategy, uv stops at the first index
+                # that has *any* version of a package, ignoring better matches on later
+                # indices. "unsafe-best-match" checks all indices and picks the best
+                # version across all of them — required when a private index provides
+                # a newer or custom build of a package that also exists on PyPI.
+                "unsafe-best-match",
                 "--output-file",
                 temp_path,
             ],

--- a/metaflow-netflixext/metaflow_extensions/nflx/plugins/conda/conda_step_decorator.py
+++ b/metaflow-netflixext/metaflow_extensions/nflx/plugins/conda/conda_step_decorator.py
@@ -95,7 +95,7 @@ class CondaRequirementStepDecorator(
     channels : List[str], default []
         Additional channels to search
     python : str, optional, default None
-        Version of Python to use, e.g. '3.7.4'. If not specified, the current version
+        Version of Python to use, e.g. '3.10.4'. If not specified, the current version
         will be used.
     disabled : bool, default False
         If set to True, uses the external environment.
@@ -184,7 +184,7 @@ class PypiRequirementStepDecorator(
         Extra arguments to pass to the resolver. For example "pre" to include
         pre-release packages.
     python : str, optional, default None
-        Version of Python to use, e.g. '3.7.4'. If not specified, the current python
+        Version of Python to use, e.g. '3.10.4'. If not specified, the current python
         version will be used.
     disabled : bool, default False
         If set to True, uses the external environment.
@@ -326,7 +326,7 @@ class PipRequirementStepDecorator(PypiRequirementStepDecorator):
     extra_indices : List[str], default []
         Additional sources to search for
     python : str, optional, default None
-        Version of Python to use, e.g. '3.7.4'. If not specified, the current python
+        Version of Python to use, e.g. '3.10.4'. If not specified, the current python
         version will be used.
     fetch_at_exec : bool, default False
         DEPRECATED -- use `@named_env(name=)` instead.

--- a/metaflow-netflixext/metaflow_extensions/nflx/plugins/conda/parsers.py
+++ b/metaflow-netflixext/metaflow_extensions/nflx/plugins/conda/parsers.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 from typing import Any, Dict, List, Optional
 
 from metaflow.metaflow_config import CONDA_SYS_DEPENDENCIES
@@ -123,6 +124,14 @@ def parse_req_value(
         line = line.strip()
         if not line:
             continue
+        # Strip inline comments (but not inside URL fragments)
+        comment_idx = line.find("#")
+        if comment_idx >= 0:
+            # Only strip if the '#' is preceded by whitespace or is at the start
+            # (avoids stripping '#egg=...' or URL fragments)
+            before = line[:comment_idx]
+            if not before or before[-1] in (" ", "\t"):
+                line = before
         splits = line.split(maxsplit=1)
         first_word = splits[0]
         if len(splits) > 1:
@@ -130,10 +139,12 @@ def parse_req_value(
         else:
             rem = None
         if first_word in ("-i", "--index-url"):
-            raise InvalidEnvironmentException(
-                "To specify a base PYPI index, set `METAFLOW_CONDA_DEFAULT_PYPI_SOURCE; "
-                "you can specify additional indices using --extra-index-url"
+            warnings.warn(
+                "Ignoring '%s' in requirements.txt; the system-configured index "
+                "or METAFLOW_CONDA_DEFAULT_PYPI_SOURCE will be used instead. "
+                "You can specify additional indices using --extra-index-url." % line
             )
+            continue
         elif first_word == "--extra-index-url" and rem:
             sources.setdefault("pypi", []).append(rem)
         elif first_word in ("-f", "--find-links", "--trusted-host") and rem:

--- a/metaflow-netflixext/metaflow_extensions/nflx/plugins/conda/pypi_package_builder.py
+++ b/metaflow-netflixext/metaflow_extensions/nflx/plugins/conda/pypi_package_builder.py
@@ -5,6 +5,7 @@ import os
 import shutil
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
 from typing import (
     TYPE_CHECKING,
     Dict,
@@ -48,17 +49,11 @@ from .utils import (
 _DEV_TRANS = str.maketrans("abcdef", "012345")
 
 
-# This is a dataclass -- can move to that when we only support 3.7+
+@dataclass
 class PackageToBuild:
-    def __init__(
-        self,
-        url: str,
-        spec: Optional[PackageSpecification] = None,
-        have_formats: Optional[List[str]] = None,
-    ):
-        self.url = url
-        self.spec = spec
-        self.have_formats = have_formats or []
+    url: str
+    spec: Optional[PackageSpecification] = None
+    have_formats: List[str] = field(default_factory=list)
 
 
 def build_pypi_packages(

--- a/metaflow-netflixext/metaflow_extensions/nflx/plugins/conda/resolvers/conda_lock_resolver.py
+++ b/metaflow-netflixext/metaflow_extensions/nflx/plugins/conda/resolvers/conda_lock_resolver.py
@@ -1,6 +1,5 @@
 # pyright: strict, reportTypeCommentUsage=false, reportMissingTypeStubs=false
 import os
-import re
 import tempfile
 
 from itertools import chain
@@ -29,7 +28,6 @@ from ..utils import (
     arch_id,
     channel_or_url,
     filter_user_reqs_by_markers,
-    get_requirement,
     parse_explicit_url_conda,
     parse_explicit_url_pypi,
     pypi_tags_from_arch,
@@ -112,42 +110,9 @@ class CondaLockResolver(Resolver):
             # We only add pip if not present
             if not any([(d == "pip" or d.startswith("pip==")) for d in conda_deps]):
                 conda_deps.append("pip")
-            # Ditto for uv -- uv 0.7.8 is the last to actually work with python 3.7
-            # but this is not listed as a condition so we enforce it here
-            # TODO: Remove this once python3.7 is retired
+            # Ditto for uv
             if not any([(d == "uv" or d.startswith("uv==")) for d in conda_deps]):
-                # Duplicate code from filter_user_reqs_by_markers in EnvsResolver.
-                # Get the minimum python version supported (major.minor) from the requested specifier.
-                spec = get_requirement(python_version_requested).specifier
-                candidate_versions = [
-                    "3.5",
-                    "3.6",
-                    "3.7",
-                    "3.8",
-                    "3.9",
-                    "3.10",
-                    "3.11",
-                    "3.12",
-                    "3.13",
-                    "3.14",
-                ]
-                matching_versions = list(spec.filter(candidate_versions))
-                if matching_versions:
-                    min_supported_py = matching_versions[0]
-                else:
-                    # fallback to the requested version (eg, ==3.10.5 → 3.10)
-                    mm = re.match(r"^.*?([0-9]+)\.([0-9]+)", python_version_requested)
-                    if mm:
-                        min_supported_py = f"{mm.group(1)}.{mm.group(2)}"
-                    else:
-                        raise CondaException(
-                            "Could not determine minimum supported Python "
-                            f"version from {python_version_requested}"
-                        )
-                if min_supported_py in ["3.5", "3.6", "3.7"]:
-                    conda_deps.append("uv==<=0.7.8")
-                else:
-                    conda_deps.append("uv")
+                conda_deps.append("uv")
 
             toml_lines = [
                 "[build-system]\n",

--- a/metaflow-netflixext/metaflow_extensions/nflx/plugins/conda/resolvers/pylock_toml_resolver.py
+++ b/metaflow-netflixext/metaflow_extensions/nflx/plugins/conda/resolvers/pylock_toml_resolver.py
@@ -1,15 +1,20 @@
 from ..env_descr import (
     PackageSpecification,
+    PypiCachePackage,
     PypiPackageSpecification,
     ResolvedEnvironment,
     EnvType,
 )
 
+from ..pypi_package_builder import PackageToBuild, build_pypi_packages
+
 from ..utils import (
+    correct_splitext,
     filter_packages_by_markers,
     get_best_compatible_packages,
     get_maximum_glibc_version,
     get_python_full_version_from_builder_envs,
+    parse_explicit_path_pypi,
     parse_explicit_url_pypi_no_hash,
     pypi_tags_from_arch,
 )
@@ -18,13 +23,22 @@ from metaflow._vendor.packaging.tags import (
     Tag,
 )
 
+from metaflow.debug import debug
 from ..utils import CondaException
 
 from . import Resolver
 from typing import Callable, Dict, Iterable, List, Any, Optional, Tuple
 import os
 import itertools
+import tempfile
 from itertools import chain
+from urllib.parse import quote as _url_quote
+
+# Placeholder wheel name used for build entries before the real wheel is known.
+# The `py3-none-any` tags are harmless here: fake specs live only in `to_build`
+# and never pass through `get_best_compatible_packages` (which uses tag-matching).
+# After building, `build_pypi_packages` replaces this with the real wheel filename.
+_FAKE_WHEEL = "_fake-1.0-py3-none-any.whl"
 
 
 class PylockTomlResolver(Resolver):
@@ -48,13 +62,16 @@ class PylockTomlResolver(Resolver):
         builder_envs: Optional[List[ResolvedEnvironment]] = None,
         base_env: Optional[ResolvedEnvironment] = None,
         file_paths: Dict[str, List[str]] = {},
-        full_id_unique_keys: Optional[Dict[str, str]] = None,
+        full_id_unique_keys: Dict[str, str] = {},
     ) -> Tuple[ResolvedEnvironment, Optional[List[ResolvedEnvironment]]]:
         # Checks on len(tom_path_list) >= 1 skiped due to get_resolver_cls()
         # only triggers this class's resolve() call when its len >= 1
         # builder_envs check also skipped.
 
         toml_path_list = file_paths["pylock_toml"]
+        debug.conda_exec(
+            "PylockTomlResolver: resolving for architecture %s" % architecture
+        )
 
         toml_path = toml_path_list[0]
         if not (
@@ -67,6 +84,7 @@ class PylockTomlResolver(Resolver):
         if not os.path.isfile(toml_path):
             raise ValueError(f"TOML file does not exist: {toml_path}")
 
+        debug.conda_exec("Reading pylock.toml from %s" % toml_path)
         toml_root_obj = self._read_toml(toml_path)
 
         if not builder_envs:
@@ -91,14 +109,18 @@ class PylockTomlResolver(Resolver):
                 "Could not determine version of Python from conda packages"
             )
 
+        debug.conda_exec(
+            "Python version: %s, glibc: %s" % (python_full_version, glibc_version)
+        )
         supported_tags = pypi_tags_from_arch(
             python_full_version,
             architecture,
             glibc_version,
         )
+        debug.conda_exec("Generated %d supported tags" % len(supported_tags))
 
         def filter_func(
-            package_dict: Dict[str, List[PackageSpecification]],
+            package_dict: Dict[str, List[PackageSpecification]]
         ) -> Dict[str, List[PackageSpecification]]:
             return PylockTomlResolver._filter_packages(
                 package_dict,
@@ -106,7 +128,8 @@ class PylockTomlResolver(Resolver):
                 architecture,
             )
 
-        resolved_env = self._translate_pylock_toml_to_resolved_env(
+        toml_dir = os.path.dirname(os.path.abspath(toml_path))
+        resolved_env, to_build_pkg_info = self._translate_pylock_toml_to_resolved_env(
             toml_root_obj,
             env_type,
             deps,
@@ -115,38 +138,94 @@ class PylockTomlResolver(Resolver):
             extras,
             architecture,
             supported_tags,
+            toml_dir,
             filter_func,
             full_id_unique_keys,
         )
 
+        # Apply marker filtering then dedup by cache_key to produce the final
+        # Dict[str, PackageToBuild] needed by build_pypi_packages.
+        # Dedup is deferred until *after* marker filtering so that packages with
+        # mutually exclusive markers sharing a URL are not incorrectly collapsed
+        # before one is filtered out.
+        filtered_build_spec_ids = {
+            id(spec)
+            for spec in filter_packages_by_markers(
+                [v.spec for _, v in to_build_pkg_info if v.spec is not None],
+                python_full_version,
+                architecture,
+            )
+        }
+        seen_build_keys: set = set()
+        to_build_dict: Dict[str, PackageToBuild] = {}
+        for cache_key, pkg_to_build in to_build_pkg_info:
+            if id(pkg_to_build.spec) not in filtered_build_spec_ids:
+                continue
+            if cache_key not in seen_build_keys:
+                seen_build_keys.add(cache_key)
+                to_build_dict[cache_key] = pkg_to_build
+            else:
+                debug.conda_exec(
+                    "Duplicate build entry after filtering: %s; keeping first"
+                    % cache_key
+                )
+
+        if to_build_dict:
+            debug.conda_exec(
+                "Need to build %d source packages: %s"
+                % (
+                    len(to_build_dict),
+                    ", ".join(
+                        "%s @ %s" % (v.spec, k) for k, v in to_build_dict.items()
+                    ),
+                )
+            )
+            if not self._conda.storage:
+                raise CondaException(
+                    "Cannot create a relocatable environment as it depends on "
+                    "source packages and no storage backend is defined: %s"
+                    % ", ".join([v.url for v in to_build_dict.values()])
+                )
+            with tempfile.TemporaryDirectory() as build_dir:
+                built_packages, builder_envs = build_pypi_packages(
+                    self._conda,
+                    self._conda.storage,
+                    python_full_version,
+                    to_build_dict,
+                    builder_envs,
+                    build_dir,
+                    architecture,
+                    supported_tags,
+                    sources.get("pypi", []),
+                )
+            # Reconstruct resolved env with built packages included
+            all_packages = list(resolved_env.packages) + built_packages
+            resolved_env = PylockTomlResolver._packages_to_resolved_env(
+                all_packages,
+                env_type,
+                deps,
+                sources,
+                extras,
+                architecture,
+                full_id_unique_keys=full_id_unique_keys,
+            )
+
+        debug.conda_exec(
+            "Resolved environment with %d packages" % len(list(resolved_env.packages))
+        )
         return (resolved_env, builder_envs)
 
     """
-    At this time, we will only support the wheels format, and explicitly reject vcs, archive, directory
-    formats.
+    Supported package formats in pylock.toml (https://peps.python.org/pep-0751/):
+    - wheels: used directly
+    - sdist: built into wheels via build_pypi_packages
+    - directory: local path packages, built into wheels
+    - vcs: git/hg/etc repositories, built into wheels
+    - archive: remote tarballs/zips, built into wheels
 
-    CONTEXT:
-
-    The formats of packages in pylock.toml (https://peps.python.org/pep-0751/) are:
-    vcs, archive, sdist+wheels, directory.
-    1. The formats are specified by the existence of one of the four inline-tables (subtables): [packages.vcs], [packages.directory],
-        [packages.sdist] within a [[package]] table. These four subtables are mutually exclusive
-        within the same package. This design ensures that a package can be specified with only one format.
-    2. [[packages.Wheels]] is a nested array table mutually exclusive with other formats except [packages.sdist], which makes
-       it a nested array only available within a [packages.sdist].
-        (More details can be found here: https://peps.python.org/pep-0751/#packages)
-
-    RATIONALE for supporting wheels only in this version:
-
-    1. Despite the user passions in adoption of uv, we want a gradual rollout of support for other formats,
-       to ensure our thorough testing.
-    2. We do not want our customers to be the first ones to encounter issues with them.
-       We will officially support those only after a thorough testing, with abundant real-world
-       pylock.py examples with those formats (which we don't have).
-    3. We don't want to skip parsing of a particular package when it's vcs/archive/directory,
-       a practice which makes the silent failures much harder to debug.
+    Non-wheel formats are built using the same mechanism as PipResolver
+    (via pypi_package_builder.build_pypi_packages).
     """
-    UNSUPPORTED_PACKAGE_SUBTYPES = {"vcs", "archive", "directory"}
 
     # TODO(https://netflix.atlassian.net/browse/MLPMF-502): wait for dependency of pylock.py to resolved, so that we could use
     # the pylock.py to read it.
@@ -208,6 +287,7 @@ class PylockTomlResolver(Resolver):
         extras: Dict[str, List[str]],
         architecture: str,
         supported_tags: List[Tag],
+        toml_dir: Optional[str] = None,
         # We take a Callable here rather than do the filtering directly
         # in this function due to:
         # 1. The filtering call requires knowledge of architecture, python_version,
@@ -222,19 +302,25 @@ class PylockTomlResolver(Resolver):
             ]
         ] = None,
         full_id_unique_keys: Dict[str, str] = {},
-    ) -> ResolvedEnvironment:
+    ) -> Tuple[ResolvedEnvironment, List[Tuple[str, PackageToBuild]]]:
 
-        packages_dict = PylockTomlResolver._pylock_toml_root_obj_to_packages(
-            toml_root_obj
+        packages_dict, to_build = PylockTomlResolver._pylock_toml_root_obj_to_packages(
+            toml_root_obj, toml_dir
         )
 
         if package_filter_func:
+            pre_filter_count = len(packages_dict)
             packages_dict = package_filter_func(packages_dict)
+            debug.conda_exec(
+                "Marker filtering: %d -> %d package names"
+                % (pre_filter_count, len(packages_dict))
+            )
 
         best_packages = get_best_compatible_packages(
             packages_dict,
             supported_tags,
         )
+        debug.conda_exec("Selected %d best compatible wheel(s)" % len(best_packages))
 
         packages: List[PackageSpecification] = list(best_packages.values())
         packages.extend(base_packages)
@@ -249,15 +335,21 @@ class PylockTomlResolver(Resolver):
             full_id_unique_keys=full_id_unique_keys,
         )
 
-        return resolved_env
+        return resolved_env, to_build
 
     @staticmethod
     # TODO(https://netflix.atlassian.net/browse/MLPMF-502): use the pylock.py object instead.
     def _toml_package_to_package_specs(
         toml_package_dict: Dict[str, Any],
-    ) -> List[PackageSpecification]:
+        toml_dir: Optional[str] = None,
+    ) -> Tuple[List[PackageSpecification], List[Tuple[str, PackageToBuild]]]:
         """
-        Convert a TOML package item to a PackageSpecification object.
+        Convert a TOML package item to PackageSpecification objects and/or
+        PackageToBuild entries for packages that need to be built from source.
+
+        Returns a tuple of:
+          - List of PackageSpecification (ready-to-use wheel specs)
+          - List of (cache_key, PackageToBuild) for packages needing a build
 
         Sample package item from pylock.toml:
 
@@ -268,66 +360,247 @@ class PylockTomlResolver(Resolver):
         wheels = [{ url = "https://pypi.netflix.net/packages/18933835517/certifi-2025.8.3-py3-none-any.whl", upload-time = 2025-08-03T03:07:45Z, size = 161216, hashes = { sha256 = "f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5" } }]
         """
 
-        if PylockTomlResolver.UNSUPPORTED_PACKAGE_SUBTYPES & set(
-            toml_package_dict.keys()
-        ):
-            raise CondaException(
-                "Currently we only support wheel packages. Please contact the Metaflow team "
-                + "if you need us to support more general cases.\n"
-                + "And please mention the following information to the Metaflow team:\n"
-                f"toml_package_dict.keys()={toml_package_dict.keys()}"
-            )
-
-        wheels = toml_package_dict.get("wheels", [])
-        if not wheels:
-            raise CondaException(
-                "We just encountered a package definition that contains no wheels.\n"
-                + "Please help us diagnose the issue by mentioning the following information to the Metaflow team:\n"
-                f"toml_package_dict={toml_package_dict}"
-            )
-
         packages: List[PackageSpecification] = []
+        to_build: List[Tuple[str, PackageToBuild]] = []
+        pkg_name = toml_package_dict.get("name", "unknown")
+        pkg_version = toml_package_dict.get("version", "")
+        pkg_marker = toml_package_dict.get("marker")
 
-        # This set of attributes will be applied to all wheels within this package.
-        package_attributes = {
-            k: toml_package_dict.get(k)
-            for k in ["name", "version", "marker"]
-            if k in toml_package_dict
-        }
+        # Handle directory packages (local path)
+        if "directory" in toml_package_dict:
+            dir_info = toml_package_dict["directory"]
+            local_path = dir_info.get("path", "")
+            if not local_path:
+                raise CondaException(
+                    "Directory package is missing 'path': %s" % toml_package_dict
+                )
+            # Resolve relative paths against the pylock.toml directory
+            if not os.path.isabs(local_path) and toml_dir:
+                local_path = os.path.normpath(os.path.join(toml_dir, local_path))
+            if dir_info.get("editable", False):
+                raise CondaException(
+                    "Cannot include an editable package: '%s'" % local_path
+                )
+            base_pkg_url = "file://%s/%s-%s.whl" % (local_path, pkg_name, pkg_version)
+            cache_key = PypiCachePackage.make_partial_cache_url(
+                base_pkg_url, is_real_url=False
+            )
+            to_build.append(
+                (
+                    cache_key,
+                    PackageToBuild(
+                        "file://" + local_path,
+                        PypiPackageSpecification(
+                            _FAKE_WHEEL,
+                            base_pkg_url,
+                            is_real_url=False,
+                            url_format=".whl",
+                            environment_marker=pkg_marker,
+                        ),
+                    ),
+                )
+            )
+            return packages, to_build
 
-        for wheel in wheels:
-            url = wheel.get("url", "")
-            file_hashes = wheel.get("hashes", {})
+        # Handle VCS packages
+        if "vcs" in toml_package_dict:
+            vcs_info = toml_package_dict["vcs"]
+            vcs_type = vcs_info.get("type", "git")
+            vcs_url = vcs_info.get("url", "")
+            vcs_path = vcs_info.get("path", "")
+            if vcs_path and not vcs_url:
+                if not os.path.isabs(vcs_path) and toml_dir:
+                    vcs_path = os.path.normpath(os.path.join(toml_dir, vcs_path))
+                vcs_url = "file://" + vcs_path
+            commit = vcs_info.get("commit-id", "")
+            if not vcs_url or not commit:
+                raise CondaException(
+                    "VCS package is missing 'url'/'path' or 'commit-id': %s"
+                    % toml_package_dict
+                )
+            build_url = "%s+%s@%s" % (vcs_type, vcs_url, commit)
+            base_pkg_url = "%s/%s" % (vcs_url, commit)
+            if "subdirectory" in vcs_info:
+                # URL-encode the subdirectory to prevent fragment injection
+                # (e.g. "src&egg=evil" would otherwise override installed package name)
+                safe_subdir = _url_quote(vcs_info["subdirectory"], safe="")
+                build_url += "#subdirectory=%s" % safe_subdir
+                base_pkg_url += "/%s" % safe_subdir
+            cache_key = PypiCachePackage.make_partial_cache_url(
+                base_pkg_url, is_real_url=False
+            )
+            to_build.append(
+                (
+                    cache_key,
+                    PackageToBuild(
+                        build_url,
+                        PypiPackageSpecification(
+                            _FAKE_WHEEL,
+                            base_pkg_url,
+                            is_real_url=False,
+                            url_format=".whl",
+                            environment_marker=pkg_marker,
+                        ),
+                    ),
+                )
+            )
+            return packages, to_build
 
-            if url and file_hashes:
+        # Handle archive packages (remote URL or local path)
+        if "archive" in toml_package_dict:
+            archive_info = toml_package_dict["archive"]
+            url = archive_info.get("url", "")
+            local_path = archive_info.get("path", "")
+            file_hashes = archive_info.get("hashes", {})
+
+            if local_path:
+                # Resolve relative paths against the pylock.toml directory
+                if not os.path.isabs(local_path) and toml_dir:
+                    local_path = os.path.normpath(os.path.join(toml_dir, local_path))
+                file_url = "file://" + local_path
+                parse_result = parse_explicit_path_pypi(file_url)
+                _, url_format = correct_splitext(os.path.basename(local_path))
+                if url_format == ".whl":
+                    # Local wheel — use directly, no build needed
+                    spec = PypiPackageSpecification(
+                        parse_result.filename,
+                        parse_result.url,
+                        is_real_url=False,
+                        url_format=parse_result.url_format,
+                        hashes=file_hashes if file_hashes else None,
+                        environment_marker=pkg_marker,
+                    )
+                    spec.add_local_file(parse_result.url_format, local_path)
+                    packages.append(spec)
+                else:
+                    # Local source archive — needs building
+                    cache_key = PypiCachePackage.make_partial_cache_url(
+                        parse_result.url, is_real_url=False
+                    )
+                    spec = PypiPackageSpecification(
+                        parse_result.filename,
+                        parse_result.url,
+                        is_real_url=False,
+                        url_format=parse_result.url_format,
+                        hashes=file_hashes if file_hashes else None,
+                        environment_marker=pkg_marker,
+                    )
+                    spec.add_local_file(parse_result.url_format, local_path)
+                    to_build.append(
+                        (
+                            cache_key,
+                            PackageToBuild(file_url, spec, [parse_result.url_format]),
+                        )
+                    )
+            elif url:
+                parse_result = parse_explicit_url_pypi_no_hash(url)
+                if parse_result.url_format == ".whl":
+                    # Remote wheel archive (e.g. flash-attn @ https://...whl) —
+                    # treat as a direct wheel, no build step needed.
+                    spec = PypiPackageSpecification(
+                        parse_result.filename,
+                        parse_result.url,
+                        url_format=parse_result.url_format,
+                        hashes=file_hashes if file_hashes else None,
+                        environment_marker=pkg_marker,
+                    )
+                    packages.append(spec)
+                else:
+                    cache_key = PypiCachePackage.make_partial_cache_url(
+                        parse_result.url, is_real_url=True
+                    )
+                    spec = PypiPackageSpecification(
+                        parse_result.filename,
+                        parse_result.url,
+                        url_format=parse_result.url_format,
+                        hashes=file_hashes if file_hashes else None,
+                        environment_marker=pkg_marker,
+                    )
+                    to_build.append((cache_key, PackageToBuild(url, spec)))
+            else:
+                raise CondaException(
+                    "Archive package is missing both 'url' and 'path': %s"
+                    % toml_package_dict
+                )
+            return packages, to_build
+
+        # Handle wheels (and sdist fallback)
+        wheels = toml_package_dict.get("wheels", [])
+
+        if wheels:
+            # This set of attributes will be applied to all wheels within this package.
+            package_attributes = {
+                k: toml_package_dict.get(k)
+                for k in ["name", "version", "marker"]
+                if k in toml_package_dict
+            }
+
+            for wheel in wheels:
+                url = wheel.get("url", "")
+                file_hashes = wheel.get("hashes", {})
+
+                if not url:
+                    raise CondaException(
+                        "Wheel entry is missing a url. "
+                        + f"Please escalate this to the Metaflow team. wheel={wheel}"
+                    )
+                if not file_hashes:
+                    raise CondaException(
+                        "We encountered a wheel package that's missing an url or a hash. "
+                        + f"Please escalate this to the Metaflow team. wheel={wheel}"
+                    )
+
                 parse_result = parse_explicit_url_pypi_no_hash(url)
                 package = PypiPackageSpecification(
                     filename=parse_result.filename,
                     url=url,
-                    hashes=file_hashes,
+                    hashes=file_hashes if file_hashes else None,
                     # Confirmed marker will only be a string in pylock.toml
                     # Thread: https://netflix.slack.com/archives/C0D3Z78F4/p1763265175272329
                     environment_marker=package_attributes.get("marker"),
                 )
 
                 packages.append(package)
-            else:
-                # Despite we can continue the loop ignoring this particular wheel,
-                # we should raise an exception to make us be aware of this issue in case
-                # it's hiding other issues.
+        elif "sdist" in toml_package_dict:
+            # No wheels available, fall back to building from sdist
+            debug.conda_exec(
+                "%s==%s: no wheels present, will build from sdist"
+                % (pkg_name, pkg_version)
+            )
+            sdist_info = toml_package_dict["sdist"]
+            url = sdist_info.get("url", "")
+            file_hashes = sdist_info.get("hashes", {})
+            if not url:
                 raise CondaException(
-                    "We encountered a wheel package that's missing an url or a hash. "
-                    + f"Please escalate this case to the Metaflow team. url={url}, file_hashes={file_hashes}"
+                    "sdist package is missing 'url': %s" % toml_package_dict
                 )
+            parse_result = parse_explicit_url_pypi_no_hash(url)
+            cache_key = PypiCachePackage.make_partial_cache_url(
+                parse_result.url, is_real_url=True
+            )
+            spec = PypiPackageSpecification(
+                parse_result.filename,
+                parse_result.url,
+                url_format=parse_result.url_format,
+                hashes=file_hashes if file_hashes else None,
+                environment_marker=pkg_marker,
+            )
+            to_build.append((cache_key, PackageToBuild(url, spec)))
+        else:
+            raise CondaException(
+                "Package has no wheels, sdist, or other recognized format: %s"
+                % toml_package_dict
+            )
 
-        return packages
+        return packages, to_build
 
     # TODO(https://netflix.atlassian.net/browse/MLPMF-502): use the open source PyLock
     # code to parse the toml file instead of parsing it to a dict as in current code.
     @staticmethod
     def _pylock_toml_root_obj_to_packages(
         toml_root_obj: Dict[str, Any],
-    ) -> Dict[str, List[PackageSpecification]]:
+        toml_dir: Optional[str] = None,
+    ) -> Tuple[Dict[str, List[PackageSpecification]], List[Tuple[str, PackageToBuild]]]:
         # Despite pylock.toml being a standard format, let's refrain the scope of
         # of supported scenarios to reduce risks.
         if toml_root_obj.get("created-by", "") != "uv":
@@ -338,6 +611,20 @@ class PylockTomlResolver(Resolver):
 
         packages = toml_root_obj.get("packages", [])
         out_dict: Dict[str, List[PackageSpecification]] = {}
+        # Keep as a list — dedup by cache_key must happen *after* marker filtering
+        # so that packages with mutually exclusive markers on the same source URL
+        # are not incorrectly collapsed before one is filtered out.
+        to_build: List[Tuple[str, PackageToBuild]] = []
+
+        # Track package types for summary
+        pkg_types: Dict[str, List[str]] = {
+            "wheels": [],
+            "sdist": [],
+            "directory": [],
+            "vcs": [],
+            "archive_local": [],
+            "archive_remote": [],
+        }
 
         for package in packages:
             if not isinstance(package, dict):
@@ -349,14 +636,74 @@ class PylockTomlResolver(Resolver):
                 # https://peps.python.org/pep-0751/#packages-name: name is required.
                 raise CondaException("Each package in 'packages' must have a name.")
 
+            version = package.get("version", "")
+            label = "%s==%s" % (name, version) if version else name
+
+            # Categorize for summary
+            if "directory" in package:
+                pkg_types["directory"].append(label)
+            elif "vcs" in package:
+                pkg_types["vcs"].append(label)
+            elif "archive" in package:
+                if package["archive"].get("path"):
+                    pkg_types["archive_local"].append(label)
+                else:
+                    pkg_types["archive_remote"].append(label)
+            elif package.get("wheels"):
+                pkg_types["wheels"].append(label)
+            elif "sdist" in package:
+                pkg_types["sdist"].append(label)
+
             # Packages of the same name can appear multiple times with different markers.
             # We will apply filtering of them later based on the environment markers.
             # See https://netflix.atlassian.net/browse/MLPMF-545.
-            out_dict.setdefault(name, []).extend(
-                PylockTomlResolver._toml_package_to_package_specs(package)
+            wheel_specs, build_entries = (
+                PylockTomlResolver._toml_package_to_package_specs(package, toml_dir)
             )
+            out_dict.setdefault(name, []).extend(wheel_specs)
+            to_build.extend(build_entries)
 
-        return out_dict
+        # Log a single summary of the pylock.toml content
+        total = sum(len(v) for v in pkg_types.values())
+        summary_parts = []
+        if pkg_types["wheels"]:
+            summary_parts.append("%d wheels" % len(pkg_types["wheels"]))
+        if pkg_types["sdist"]:
+            summary_parts.append(
+                "%d sdist-only (need build): %s"
+                % (len(pkg_types["sdist"]), ", ".join(pkg_types["sdist"]))
+            )
+        if pkg_types["directory"]:
+            summary_parts.append(
+                "%d directory (need build): %s"
+                % (len(pkg_types["directory"]), ", ".join(pkg_types["directory"]))
+            )
+        if pkg_types["vcs"]:
+            summary_parts.append(
+                "%d vcs (need build): %s"
+                % (len(pkg_types["vcs"]), ", ".join(pkg_types["vcs"]))
+            )
+        if pkg_types["archive_local"]:
+            summary_parts.append(
+                "%d local archive: %s"
+                % (
+                    len(pkg_types["archive_local"]),
+                    ", ".join(pkg_types["archive_local"]),
+                )
+            )
+        if pkg_types["archive_remote"]:
+            summary_parts.append(
+                "%d remote archive (need build): %s"
+                % (
+                    len(pkg_types["archive_remote"]),
+                    ", ".join(pkg_types["archive_remote"]),
+                )
+            )
+        debug.conda_exec(
+            "pylock.toml: %d packages — %s" % (total, "; ".join(summary_parts))
+        )
+
+        return out_dict, to_build
 
     @staticmethod
     def _packages_to_resolved_env(

--- a/metaflow-netflixext/metaflow_extensions/nflx/plugins/conda/resolvers/pylock_toml_resolver.py
+++ b/metaflow-netflixext/metaflow_extensions/nflx/plugins/conda/resolvers/pylock_toml_resolver.py
@@ -148,6 +148,7 @@ class PylockTomlResolver(Resolver):
         # Dedup is deferred until *after* marker filtering so that packages with
         # mutually exclusive markers sharing a URL are not incorrectly collapsed
         # before one is filtered out.
+        # filter_packages_by_markers preserves object identity — id() is safe here.
         filtered_build_spec_ids = {
             id(spec)
             for spec in filter_packages_by_markers(
@@ -381,7 +382,11 @@ class PylockTomlResolver(Resolver):
                 raise CondaException(
                     "Cannot include an editable package: '%s'" % local_path
                 )
-            base_pkg_url = "file://%s/%s-%s.whl" % (local_path, pkg_name, pkg_version)
+            base_pkg_url = "file://%s/%s-%s.whl" % (
+                local_path,
+                pkg_name,
+                pkg_version or "0",  # PEP 751 allows omitting version for local deps
+            )
             cache_key = PypiCachePackage.make_partial_cache_url(
                 base_pkg_url, is_real_url=False
             )
@@ -693,7 +698,9 @@ class PylockTomlResolver(Resolver):
             )
         if pkg_types["archive_remote"]:
             summary_parts.append(
-                "%d remote archive (need build): %s"
+                # Note: .whl URLs in this bucket are used directly (no build);
+                # other formats go through build_pypi_packages.
+                "%d remote archive (may need build): %s"
                 % (
                     len(pkg_types["archive_remote"]),
                     ", ".join(pkg_types["archive_remote"]),

--- a/metaflow-netflixext/metaflow_extensions/nflx/plugins/conda/utils.py
+++ b/metaflow-netflixext/metaflow_extensions/nflx/plugins/conda/utils.py
@@ -83,8 +83,7 @@ _BUILDER_ENVS_PACKAGES = (
     "wheel",
     "tomli",
     "setuptools<82",  # pkg_resources removed in setuptools 82; many packages still need it
-    "uv<=0.7.8; python_version<'3.8'",
-    "uv ; python_version>='3.8'",
+    "uv",
 )
 
 
@@ -941,20 +940,6 @@ def version_to_str(v: Version, overrides: Dict[str, Any]) -> str:
 # HACK to prevent looking for python versions that do not exist on
 # conda-forge.
 version_maps = {
-    "3.7.4": "3.7.5",
-    "3.7.7": "3.7.8",
-    "3.7.11": "3.7.12",
-    "3.7.13": "3.7.12",
-    "3.7.14": "3.7.12",
-    "3.7.15": "3.7.12",
-    "3.7.16": "3.7.12",
-    "3.7.17": "3.7.12",
-    "3.8.7": "3.8.8",
-    "3.8.9": "3.8.10",
-    "3.8.11": "3.8.12",
-    "3.9.3": "3.9.4",
-    "3.9.8": "3.9.9",
-    "3.9.11": "3.9.12",
     "3.10.3": "3.10.4",
 }
 


### PR DESCRIPTION
## Summary

These PRs were merged to `corp/mli-metaflow-custom` between the OSS fork cut (mid-April) and the migration PR (#66) landing (June 5). They were never ported to `metaflow-nflx-extensions`, leaving the OSS package behind the internal implementation. rcledat flagged this as breaking eval work.

### What's in this PR

**#1749 — pylock_toml_resolver sdist/vcs/archive support (most critical)**
- `pylock_toml_resolver.py`: Support `sdist`, `vcs` (git/hg/etc), `directory`, and `archive` package types — previously only wheels were supported. Adds debug logging, marker filtering after building, and a clobber guard for duplicate build entries.
- `parsers.py`: Strip inline comments in `requirements.txt` without stripping URL fragments. Demote `--index-url` from hard error to warning+continue.
- `conda_flow_mutator.py`: Add `--index-strategy unsafe-best-match` to `uv pip compile` so all indices are treated equally.

**#1886 — Fix VCS commit field to match PEP 751**
- `pylock_toml_resolver.py`: Use `commit-id` field (not `commit`) per [PEP 751](https://peps.python.org/pep-0751/). Also support `vcs.path` for local VCS packages.

**#1785 — Drop Python < 3.10 support**
- `utils.py`: Simplify uv dep (remove `python_version` marker), remove 3.7/3.8/3.9 version maps.
- `pypi_package_builder.py`: Convert `PackageToBuild` to proper `@dataclass`.
- `conda_lock_resolver.py`: Remove the complex uv version selection logic gated on minimum Python version; just append `"uv"` unconditionally. Remove unused `re` and `get_requirement` imports.
- `conda_flow_decorator.py`, `conda_step_decorator.py`: Update docstring examples from `3.7.4` to `3.10.4`.

**#1915 — Remote Wheel Archive**
- `pylock_toml_resolver.py`: When an `archive` entry has a remote `.whl` URL, use it directly as a wheel instead of routing through the build pipeline.

## Context

The OSS fork was cut in mid-April but the migration PR (#66) wasn't merged until June 5. Internal PRs merged in between were never ported to OSS. The dependency declaration moved but the source code improvements didn't. This PR fixes the gap for the conda/pylock resolver — the most impactful missing piece.

## Test plan

- [ ] Verify existing `pylock_toml_resolver_test.py` tests still pass
- [ ] Test pylock.toml files with sdist-only packages (no wheels) get built correctly
- [ ] Test pylock.toml files with VCS entries using `commit-id` field parse correctly
- [ ] Test pylock.toml files with remote `.whl` archive entries are used directly (no build)
- [ ] Verify `--index-url` lines in requirements.txt emit a warning instead of raising
- [ ] Verify `uv pip compile` works with `--index-strategy unsafe-best-match`

🤖 Generated with [Claude Code](https://claude.com/claude-code)