### PR TITLE
conda: propagate remote micromamba path to Runner-spawned child processes

### DIFF
--- a/metaflow-netflixext/metaflow_extensions/netflixext/plugins/conda/conda.py
+++ b/metaflow-netflixext/metaflow_extensions/netflixext/plugins/conda/conda.py
@@ -1978,16 +1978,28 @@ class Conda(object):
                         if err:
                             raise err
         else:
-            _remote_micromamba = os.environ.get("_METAFLOW_CONDA_MICROMAMBA")
-            if _remote_micromamba and os.path.isfile(_remote_micromamba):
-                # The outer step already bootstrapped micromamba remotely (e.g. via
-                # _install_remote_conda). Reuse it so Runner-spawned inner flows
-                # don't need it on PATH.
+            # Check whether _install_remote_conda() already placed a micromamba binary
+            # in a well-known location (../conda_env/ or ./conda_env/).  This happens
+            # when Runner is invoked inside a step that bootstrapped remotely — the
+            # binary is on disk but not on PATH, so which() won't find it.
+            _parent = os.path.dirname(os.getcwd())
+            _remote_bin = next(
+                (
+                    p
+                    for p in [
+                        os.path.join(_parent, "conda_env", "micromamba"),
+                        os.path.join(os.getcwd(), "conda_env", "micromamba"),
+                    ]
+                    if os.path.isfile(p) and os.access(p, os.X_OK)
+                ),
+                None,
+            )
+            if _remote_bin is not None:
                 self._conda_executable_type = "micromamba"
                 self.is_non_conda_exec = True
                 self._bins = {
-                    "conda": _remote_micromamba,
-                    "micromamba": _remote_micromamba,
+                    "conda": _remote_bin,
+                    "micromamba": _remote_bin,
                 }
             else:
                 self._bins = {
@@ -2147,9 +2159,6 @@ class Conda(object):
         self._bins = {"conda": final_path, "micromamba": final_path}
         self._conda_executable_type = "micromamba"
         self.is_non_conda_exec = True
-        # Advertise the binary path so that child processes (e.g. Runner-spawned
-        # inner flows) can find it without needing it on PATH.
-        os.environ["_METAFLOW_CONDA_MICROMAMBA"] = final_path
 
     def _validate_conda_installation(self) -> Optional[Exception]:
         # If this is installed in CONDA_LOCAL_PATH look for special marker

--- a/metaflow-netflixext/metaflow_extensions/netflixext/plugins/conda/conda.py
+++ b/metaflow-netflixext/metaflow_extensions/netflixext/plugins/conda/conda.py
@@ -1978,26 +1978,38 @@ class Conda(object):
                         if err:
                             raise err
         else:
-            self._bins = {
-                self._conda_executable_type: which(self._conda_executable_type),
-                "conda-lock": which("conda-lock"),
-                # We can install micromamba in $HOME/.local/bin so we look there too
-                "micromamba": which(
-                    "micromamba",
-                    path=":".join(
-                        [
-                            os.environ.get("PATH", ""),
-                            "%s/.local/bin" % os.environ.get("HOME", ""),
-                        ]
+            _remote_micromamba = os.environ.get("_METAFLOW_CONDA_MICROMAMBA")
+            if _remote_micromamba and os.path.isfile(_remote_micromamba):
+                # The outer step already bootstrapped micromamba remotely (e.g. via
+                # _install_remote_conda). Reuse it so Runner-spawned inner flows
+                # don't need it on PATH.
+                self._conda_executable_type = "micromamba"
+                self.is_non_conda_exec = True
+                self._bins = {
+                    "conda": _remote_micromamba,
+                    "micromamba": _remote_micromamba,
+                }
+            else:
+                self._bins = {
+                    self._conda_executable_type: which(self._conda_executable_type),
+                    "conda-lock": which("conda-lock"),
+                    # We can install micromamba in $HOME/.local/bin so we look there too
+                    "micromamba": which(
+                        "micromamba",
+                        path=":".join(
+                            [
+                                os.environ.get("PATH", ""),
+                                "%s/.local/bin" % os.environ.get("HOME", ""),
+                            ]
+                        ),
                     ),
-                ),
-                "cph": which("cph"),
-                "pip": which("pip"),
-            }
-            self._bins["conda"] = self._bins[self._conda_executable_type]
-            err = self._validate_conda_installation()
-            if err:
-                raise err
+                    "cph": which("cph"),
+                    "pip": which("pip"),
+                }
+                self._bins["conda"] = self._bins[self._conda_executable_type]
+                err = self._validate_conda_installation()
+                if err:
+                    raise err
 
     def _ensure_micromamba(self) -> str:
         args = [
@@ -2135,6 +2147,9 @@ class Conda(object):
         self._bins = {"conda": final_path, "micromamba": final_path}
         self._conda_executable_type = "micromamba"
         self.is_non_conda_exec = True
+        # Advertise the binary path so that child processes (e.g. Runner-spawned
+        # inner flows) can find it without needing it on PATH.
+        os.environ["_METAFLOW_CONDA_MICROMAMBA"] = final_path
 
     def _validate_conda_installation(self) -> Optional[Exception]:
         # If this is installed in CONDA_LOCAL_PATH look for special marker

--- a/tests/plugins/conda/test_ensure_local_conda.py
+++ b/tests/plugins/conda/test_ensure_local_conda.py
@@ -43,6 +43,7 @@ class TestEnsureLocalCondaPathProbing(unittest.TestCase):
     def test_finds_micromamba_in_parent_conda_env(self):
         """../conda_env/micromamba is found when Runner runs inside a remote step."""
         with tempfile.TemporaryDirectory() as base:
+            base = os.path.realpath(base)  # macOS: /var/folders → /private/var/folders
             # Layout _install_remote_conda() produces when parent dir is writable:
             #   base/conda_env/micromamba   ← installed binary
             #   base/task/                  ← CWD of step execution
@@ -68,6 +69,7 @@ class TestEnsureLocalCondaPathProbing(unittest.TestCase):
     def test_finds_micromamba_in_cwd_conda_env(self):
         """./conda_env/micromamba is found as fallback when ../conda_env doesn't exist."""
         with tempfile.TemporaryDirectory() as base:
+            base = os.path.realpath(base)  # macOS: /var/folders → /private/var/folders
             # Layout when parent dir is not writable:
             #   base/conda_env/micromamba   ← installed binary (same dir as CWD)
             binary_path = os.path.join(base, "conda_env", "micromamba")
@@ -90,6 +92,7 @@ class TestEnsureLocalCondaPathProbing(unittest.TestCase):
     def test_non_executable_binary_not_used(self):
         """A non-executable file in conda_env/ is skipped (falls through to which())."""
         with tempfile.TemporaryDirectory() as base:
+            base = os.path.realpath(base)  # macOS: /var/folders → /private/var/folders
             task_dir = os.path.join(base, "task")
             os.makedirs(task_dir)
             binary_path = os.path.join(base, "conda_env", "micromamba")
@@ -121,6 +124,7 @@ class TestEnsureLocalCondaPathProbing(unittest.TestCase):
     def test_parent_conda_env_takes_priority_over_cwd(self):
         """../conda_env/micromamba is preferred over ./conda_env/micromamba when both exist."""
         with tempfile.TemporaryDirectory() as base:
+            base = os.path.realpath(base)  # macOS: /var/folders → /private/var/folders
             task_dir = os.path.join(base, "task")
             os.makedirs(task_dir)
             parent_binary = os.path.join(base, "conda_env", "micromamba")

--- a/tests/plugins/conda/test_ensure_local_conda.py
+++ b/tests/plugins/conda/test_ensure_local_conda.py
@@ -1,0 +1,119 @@
+"""
+Tests for _ensure_local_conda() path-probing logic.
+
+Covers the flow-of-flows scenario: Runner is called inside a step that ran
+_install_remote_conda() during bootstrap, placing micromamba at ../conda_env/
+or ./conda_env/ but NOT adding it to PATH.  _ensure_local_conda() must find
+it without relying on shutil.which().
+"""
+
+import os
+import stat
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+def _make_executable(path):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write("#!/bin/sh\n")
+    os.chmod(path, stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP)
+
+
+class TestEnsureLocalCondaPathProbing(unittest.TestCase):
+    """_ensure_local_conda() finds micromamba placed by _install_remote_conda()."""
+
+    def setUp(self):
+        os.environ.setdefault("METAFLOW_CONDA_PYPI_DEPENDENCY_RESOLVER", "uv")
+        from metaflow_extensions.netflixext.plugins.conda.conda import Conda
+
+        self._Conda = Conda
+        self._original_cwd = os.getcwd()
+
+    def tearDown(self):
+        os.chdir(self._original_cwd)
+
+    def _echo(self, *args, **kwargs):
+        pass
+
+    def _conda(self):
+        return self._Conda(echo=self._echo, datastore_type="local")
+
+    def test_finds_micromamba_in_parent_conda_env(self):
+        """../conda_env/micromamba is found when Runner runs inside a remote step."""
+        with tempfile.TemporaryDirectory() as base:
+            # Layout _install_remote_conda() produces when parent dir is writable:
+            #   base/conda_env/micromamba   ← installed binary
+            #   base/task/                  ← CWD of step execution
+            task_dir = os.path.join(base, "task")
+            os.makedirs(task_dir)
+            binary_path = os.path.join(base, "conda_env", "micromamba")
+            _make_executable(binary_path)
+
+            os.chdir(task_dir)
+            conda = self._conda()
+
+            with patch(
+                "metaflow_extensions.netflixext.plugins.conda.conda.CONDA_LOCAL_PATH",
+                None,
+            ):
+                conda._ensure_local_conda()
+
+            self.assertEqual(conda._bins.get("micromamba"), binary_path)
+            self.assertEqual(conda._bins.get("conda"), binary_path)
+            self.assertEqual(conda._conda_executable_type, "micromamba")
+            self.assertTrue(conda.is_non_conda_exec)
+
+    def test_finds_micromamba_in_cwd_conda_env(self):
+        """./conda_env/micromamba is found as fallback when ../conda_env doesn't exist."""
+        with tempfile.TemporaryDirectory() as base:
+            # Layout when parent dir is not writable:
+            #   base/conda_env/micromamba   ← installed binary (same dir as CWD)
+            binary_path = os.path.join(base, "conda_env", "micromamba")
+            _make_executable(binary_path)
+
+            os.chdir(base)
+            conda = self._conda()
+
+            with patch(
+                "metaflow_extensions.netflixext.plugins.conda.conda.CONDA_LOCAL_PATH",
+                None,
+            ):
+                conda._ensure_local_conda()
+
+            self.assertEqual(conda._bins.get("micromamba"), binary_path)
+            self.assertEqual(conda._bins.get("conda"), binary_path)
+            self.assertEqual(conda._conda_executable_type, "micromamba")
+            self.assertTrue(conda.is_non_conda_exec)
+
+    def test_non_executable_binary_not_used(self):
+        """A non-executable file in conda_env/ is skipped (falls through to which())."""
+        with tempfile.TemporaryDirectory() as base:
+            task_dir = os.path.join(base, "task")
+            os.makedirs(task_dir)
+            binary_path = os.path.join(base, "conda_env", "micromamba")
+            os.makedirs(os.path.dirname(binary_path), exist_ok=True)
+            with open(binary_path, "w") as f:
+                f.write("#!/bin/sh\n")
+            # NOT made executable — os.access(p, os.X_OK) should fail
+
+            os.chdir(task_dir)
+            conda = self._conda()
+
+            with patch(
+                "metaflow_extensions.netflixext.plugins.conda.conda.CONDA_LOCAL_PATH",
+                None,
+            ):
+                # Should fall through to which(). In the test environment micromamba
+                # may or may not be on PATH, so we just assert it didn't pick up
+                # the non-executable file.
+                try:
+                    conda._ensure_local_conda()
+                except Exception:
+                    pass
+
+            # Even if _ensure_local_conda raised, the non-executable path must not
+            # have been selected.
+            if conda._bins is not None:
+                self.assertNotEqual(conda._bins.get("micromamba"), binary_path)

--- a/tests/plugins/conda/test_ensure_local_conda.py
+++ b/tests/plugins/conda/test_ensure_local_conda.py
@@ -117,3 +117,25 @@ class TestEnsureLocalCondaPathProbing(unittest.TestCase):
             # have been selected.
             if conda._bins is not None:
                 self.assertNotEqual(conda._bins.get("micromamba"), binary_path)
+
+    def test_parent_conda_env_takes_priority_over_cwd(self):
+        """../conda_env/micromamba is preferred over ./conda_env/micromamba when both exist."""
+        with tempfile.TemporaryDirectory() as base:
+            task_dir = os.path.join(base, "task")
+            os.makedirs(task_dir)
+            parent_binary = os.path.join(base, "conda_env", "micromamba")
+            cwd_binary = os.path.join(task_dir, "conda_env", "micromamba")
+            _make_executable(parent_binary)
+            _make_executable(cwd_binary)
+
+            os.chdir(task_dir)
+            conda = self._conda()
+
+            with patch(
+                "metaflow_extensions.netflixext.plugins.conda.conda.CONDA_LOCAL_PATH",
+                None,
+            ):
+                conda._ensure_local_conda()
+
+            self.assertEqual(conda._bins.get("micromamba"), parent_binary)
+            self.assertEqual(conda._bins.get("conda"), parent_binary)


### PR DESCRIPTION
## Summary

Fixes #87 — conda does not find installed micromamba when using `Runner` inside a `FlowSpec`.

**Root cause:** `_install_remote_conda()` (run inside the `remote_bootstrap.py` subprocess) installs micromamba to `../conda_env/micromamba` (not on `PATH`). When `Runner(...).run(...)` is called inside the same step, the step's Python process creates a new `Conda(mode="local")` instance. `_ensure_local_conda()` searches only `PATH` and `~/.local/bin` via `shutil.which()` — it never finds the binary that the bootstrap installed.

**Fix (Option 3):** `_ensure_local_conda()` now probes the two deterministic paths that `_install_remote_conda()` always uses (`../conda_env/micromamba`, `./conda_env/micromamba`) before falling back to `which()`. Both the bootstrap subprocess and the step process share the same CWD, so the probe is reliable. If the binary is found and executable, it's used directly with `conda_executable_type="micromamba"` and `is_non_conda_exec=True` — matching the state that `_install_remote_conda()` establishes. All other cases fall through to the original `which()` logic unchanged.

**Why not an env var?** Setting `os.environ` in `_install_remote_conda()` only affects the `remote_bootstrap.py` subprocess; those changes die when that process exits and are never visible to the step's Python process. The env-var-via-file approach (write path → bash `export` → child inherits) would work but requires touching `remote_bootstrap.py` and `conda_environment.py:bootstrap_commands`. Path probing is simpler and equally correct since `_install_remote_conda()` always uses the same two candidate paths.

## Test plan

- [ ] Flow-of-flows with `@conda` on the inner flow, outer step on Kubernetes (no micromamba on image PATH) — no longer fails with "No micromamba binary found"
- [ ] Local runs unaffected — `../conda_env/micromamba` won't exist locally so path probing falls through to the original `which()` path
- [ ] Multiple `Runner` calls in the same step all find the binary via the path probe