### PR TITLE
netflixext: install nflx_compat shim during config discovery, not just toplevel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
           set -x
           which pytest
           mkdir .metaflow
-          pytest tests/environments tests/plugins/conda -v \
+          pytest tests/environments tests/plugins/conda tests/namespace -v \
             --junit-xml=junit.xml \
             --cov=metaflow_extensions \
             --cov-report=term-missing \

--- a/metaflow-netflixext/metaflow_extensions/netflixext/config/mfextinit_netflixext.py
+++ b/metaflow-netflixext/metaflow_extensions/netflixext/config/mfextinit_netflixext.py
@@ -1,4 +1,18 @@
 import os
+
+# Install the nflx->netflixext backward-compat import shim as early as possible.
+# This config descriptor is imported during Metaflow's extension *discovery*
+# (metaflow_config bootstrap), which runs BEFORE plugin resolution. Other
+# extensions (e.g. the internal nflx-metaflow) contribute step decorators whose
+# classes import `metaflow_extensions.nflx.plugins.conda.*` and are imported
+# during `resolve_plugins(...)`. The toplevel module (which also calls install())
+# is merged into metaflow's namespace only AFTER plugin resolution, so relying on
+# it alone leaves the shim inactive when those plugin classes load. install() is
+# idempotent, so the redundant toplevel call is harmless.
+from ..nflx_compat import install as _install_nflx_compat
+
+_install_nflx_compat()
+
 from metaflow.metaflow_config import (
     DATASTORE_SYSROOT_S3,
     DATASTORE_SYSROOT_AZURE,

--- a/tests/namespace/conftest.py
+++ b/tests/namespace/conftest.py
@@ -1,0 +1,12 @@
+"""Shared setup for the namespace / nflx_compat shim tests.
+
+Importing metaflow once, up front, fully initializes its plugin registry
+(``resolve_plugins`` imports every step-decorator class, including the conda
+ones). The shim tests then import ``metaflow_extensions.nflx.plugins.conda.*``
+modules directly; doing so before metaflow is initialized would re-enter
+metaflow's bootstrap and hit the conda circular-import. Loading metaflow here
+makes the suite order-independent (it otherwise only passes when a sibling
+test file happens to import metaflow first).
+"""
+
+import metaflow  # noqa: F401  (imported for its initialization side effect)

--- a/tests/namespace/test_nflx_compat_shim.py
+++ b/tests/namespace/test_nflx_compat_shim.py
@@ -8,9 +8,30 @@ code continues to work without modification.
 """
 
 import importlib
+import importlib.util
 import sys
 
 import pytest
+
+
+def _nflx_namespace_available():
+    """True only if some installed package provides the metaflow_extensions.nflx
+    namespace (e.g. the internal nflx-metaflow / nflx-fastdata). The shim
+    redirects nflx.plugins.conda.* children but never the bare `nflx` parent —
+    that parent must be importable on its own. In a pure-OSS install (just
+    metaflow-netflixext) nothing provides it, so the nflx-import tests below are
+    only meaningful when such a package is co-installed."""
+    try:
+        return importlib.util.find_spec("metaflow_extensions.nflx") is not None
+    except (ImportError, ValueError):
+        return False
+
+
+requires_nflx_namespace = pytest.mark.skipif(
+    not _nflx_namespace_available(),
+    reason="needs a package providing the metaflow_extensions.nflx namespace "
+    "(e.g. nflx-metaflow); pure-OSS metaflow-netflixext does not provide it",
+)
 
 
 @pytest.fixture(autouse=True)
@@ -67,6 +88,7 @@ class TestNflxCompatShim:
         _uninstall_shim()
         assert count == 1, f"Expected 1 shim finder, got {count}"
 
+    @requires_nflx_namespace
     def test_nflx_conda_import_resolves_via_shim(self, shim_installed):
         """from metaflow_extensions.nflx.plugins.conda.* must resolve after shim."""
         nflx_mod = importlib.import_module(
@@ -80,6 +102,7 @@ class TestNflxCompatShim:
             "same object as netflixext.plugins.conda.conda_step_decorator"
         )
 
+    @requires_nflx_namespace
     def test_nflx_conda_import_registered_in_sys_modules(self, shim_installed):
         """Resolved nflx.* aliases must be cached in sys.modules."""
         importlib.import_module("metaflow_extensions.nflx.plugins.conda.env_descr")
@@ -113,3 +136,51 @@ class TestNflxCompatShim:
             # nflx-fastdata not installed in this environment — shim correctly did
             # not intercept (would have been a different error if it had tried)
             pass
+
+
+class TestShimInstalledEarly:
+    """The shim must be active BEFORE Metaflow resolves plugins, not just after
+    its toplevel module loads.
+
+    Metaflow loads extension *descriptors* (config/plugins mfextinit) during
+    discovery, then imports plugin *classes* in ``resolve_plugins(...)``, then
+    merges extension *toplevel* modules last. Another installed extension (e.g.
+    the internal nflx-metaflow) contributes step decorators whose classes import
+    ``metaflow_extensions.nflx.plugins.conda.*`` at resolve time — so if the shim
+    is installed only from the toplevel it is too late and ``import metaflow``
+    raises ModuleNotFoundError for that combination. The config descriptor, which
+    loads during discovery, must install it.
+    """
+
+    def test_config_descriptor_installs_shim_on_import(self):
+        # Import metaflow first so metaflow.metaflow_config is fully initialized.
+        # Re-executing the config descriptor below does
+        # `from metaflow.metaflow_config import ...`; without metaflow already
+        # loaded that would re-enter metaflow's bootstrap and hit the conda
+        # circular-import, which is unrelated to what we're asserting here.
+        import metaflow  # noqa: F401
+
+        from metaflow_extensions.netflixext.nflx_compat import _NflxCompatFinder
+
+        # Remove the finder, then force the config descriptor to re-execute and
+        # prove that *it* reinstalls the finder (i.e. the early install lives in
+        # the config descriptor, which loads during discovery — before plugin
+        # resolution — not only in the toplevel, which loads too late for other
+        # extensions' plugins that import metaflow_extensions.nflx.* at resolve time).
+        _uninstall_shim()
+        sys.modules.pop(
+            "metaflow_extensions.netflixext.config.mfextinit_netflixext", None
+        )
+        try:
+            importlib.import_module(
+                "metaflow_extensions.netflixext.config.mfextinit_netflixext"
+            )
+            assert any(
+                isinstance(f, _NflxCompatFinder) for f in sys.meta_path
+            ), (
+                "importing the netflixext config descriptor must install the "
+                "nflx_compat finder (it loads before plugin resolution); a "
+                "toplevel-only install is too late for other extensions' plugins"
+            )
+        finally:
+            _uninstall_shim()

--- a/tests/namespace/test_nflx_compat_shim.py
+++ b/tests/namespace/test_nflx_compat_shim.py
@@ -175,9 +175,7 @@ class TestShimInstalledEarly:
             importlib.import_module(
                 "metaflow_extensions.netflixext.config.mfextinit_netflixext"
             )
-            assert any(
-                isinstance(f, _NflxCompatFinder) for f in sys.meta_path
-            ), (
+            assert any(isinstance(f, _NflxCompatFinder) for f in sys.meta_path), (
                 "importing the netflixext config descriptor must install the "
                 "nflx_compat finder (it loads before plugin resolution); a "
                 "toplevel-only install is too late for other extensions' plugins"

--- a/tests/plugins/conda/test_credential_stripping_callsites.py
+++ b/tests/plugins/conda/test_credential_stripping_callsites.py
@@ -10,7 +10,7 @@ calling _safe_netloc would cause these tests to fail.
 
 import metaflow  # must be imported first to initialize the extension system
 
-from metaflow_extensions.nflx.plugins.conda.env_descr import (
+from metaflow_extensions.netflixext.plugins.conda.env_descr import (
     CondaCachePackage,
     PypiCachePackage,
     PypiPackageSpecification,

--- a/tests/plugins/conda/test_strip_url_credentials.py
+++ b/tests/plugins/conda/test_strip_url_credentials.py
@@ -15,7 +15,7 @@ sys.path.insert(
 )
 
 from urllib.parse import urlparse
-from metaflow_extensions.nflx.plugins.conda.utils import (
+from metaflow_extensions.netflixext.plugins.conda.utils import (
     strip_url_credentials,
     _safe_netloc,
 )


### PR DESCRIPTION
## Problem

PR #93 moved metaflow-netflixext's namespace `metaflow_extensions.nflx` → `metaflow_extensions.netflixext` and added a backward-compat meta-path finder (`netflixext/nflx_compat.py`) that redirects legacy `metaflow_extensions.nflx.*` imports to `metaflow_extensions.netflixext.*`.

`install()` was called **only** from `netflixext/toplevel/nflxext_toplevel.py`. Metaflow merges extension *toplevel* modules **last** — after `resolve_plugins()`. So when another installed extension contributes step-decorator plugins whose classes import `metaflow_extensions.nflx.plugins.conda.*` at import time, those classes are imported during plugin resolution **before** the toplevel runs `install()`, and `import metaflow` crashes:

```
ModuleNotFoundError: No module named 'metaflow_extensions.nflx.plugins.conda.conda_step_decorator'
  ... in resolve_plugins("step_decorator")
```

This is **latent on pure OSS** (no installed extension triggers it, so CI stayed green), but it breaks any environment that combines the post-#93 `netflixext` namespace with a package that contributes such plugins (e.g. Netflix-internal `nflx-metaflow`).

## Fix

Also call `nflx_compat.install()` from `netflixext/config/mfextinit_netflixext.py`. The **config descriptor** loads during extension *discovery* (metaflow_config bootstrap), which runs **before** plugin resolution. `install()` is idempotent, so the existing toplevel call is a harmless backstop.

## Test hardening

`tests/namespace/` was added by #93 but was **never wired into CI**, which is why the shim tests' fragility went unnoticed. This PR:

- Adds `tests/namespace/conftest.py` that imports metaflow once, making the suite order-independent (direct `nflx.plugins.conda.*` imports otherwise hit the conda circular-import unless a sibling test imported metaflow first).
- Adds a `TestShimInstalledEarly` regression test that **fails if `install()` is reverted to toplevel-only**.
- Gates the two tests that import `metaflow_extensions.nflx.*` behind a `skipif` so they run in an integration env (where a package provides the `nflx` namespace) and skip cleanly in pure OSS.
- Runs `tests/namespace` in `test.yml`.

## Verification

- Pure-OSS venv (`metaflow` + editable `metaflow-netflixext`): `tests/namespace` → **9 passed, 2 skipped**.
- Integration venv (with `nflx-metaflow`): `tests/namespace` → **11 passed, 0 skipped**; plain `import metaflow` now succeeds and `nflx.plugins.conda` correctly redirects to `netflixext`.
- Regression test confirmed to fail when the fix is reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)