### PR TITLE
prebuilt: parallelize per-step image builds with ThreadPoolExecutor

### DIFF
--- a/metaflow-prebuilt/README.md
+++ b/metaflow-prebuilt/README.md
@@ -70,6 +70,7 @@ Select backends via environment variables:
 | `METAFLOW_PREBUILT_BUILD_SERVICE` | `docker` | Which build service to use |
 | `METAFLOW_PREBUILT_IMAGE_REGISTRY` | `dockerhub` | Which image registry to use |
 | `METAFLOW_PREBUILT_REGISTRY_CACHE` | `1` | Reuse existing immutable prebuilt image tags when available |
+| `METAFLOW_PREBUILT_BUILD_WORKERS` | `min(unique image count, 8)` | Max concurrent prebuilt image builds |
 
 ## Extension points
 

--- a/metaflow-prebuilt/README.md
+++ b/metaflow-prebuilt/README.md
@@ -69,6 +69,7 @@ Select backends via environment variables:
 |---|---|---|
 | `METAFLOW_PREBUILT_BUILD_SERVICE` | `docker` | Which build service to use |
 | `METAFLOW_PREBUILT_IMAGE_REGISTRY` | `dockerhub` | Which image registry to use |
+| `METAFLOW_PREBUILT_REGISTRY_CACHE` | `1` | Reuse existing immutable prebuilt image tags when available |
 
 ## Extension points
 

--- a/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/build_service.py
+++ b/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/build_service.py
@@ -2,7 +2,7 @@ import importlib.metadata
 import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Optional, TYPE_CHECKING
+from typing import Any, Callable, Dict, Optional, TYPE_CHECKING, Tuple
 
 if TYPE_CHECKING:
     pass
@@ -38,6 +38,7 @@ class DockerfileBuildOptions:
     """
 
     buildkit_deferred_input_mounts: bool = False
+    bootstrap_pip_install_options: Tuple[str, ...] = ()
 
 
 class DockerBuildService(ABC):

--- a/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/build_service.py
+++ b/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/build_service.py
@@ -96,6 +96,17 @@ class DockerBuildService(ABC):
 
         return DockerfileBuildOptions()
 
+    def image_identity_suffix(self) -> str:
+        """Return an optional discriminator for build-output identity.
+
+        The prebuilt image tag already includes the env id, base image, and arch.
+        Build backends that can change pushed image compatibility or layer encoding
+        should return a short stable suffix so registry reuse cannot hide that
+        setting.
+        """
+
+        return ""
+
     @classmethod
     def from_config(cls) -> "DockerBuildService":
         """Resolve and instantiate the build service selected by

--- a/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_build_install.py
+++ b/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_build_install.py
@@ -73,7 +73,7 @@ def _metaflow_plugin_categories() -> List[str]:
     This module writes ``METAFLOW_HOME/config.json`` before importing
     ``metaflow``. Importing ``metaflow.extension_support.plugins`` directly would
     execute Metaflow's package init too early, so read the installed source file
-    and parse the ``_plugin_categories`` literal instead.
+    and parse the source for the ``_plugin_categories`` dict keys instead.
     """
 
     spec = importlib.machinery.PathFinder.find_spec("metaflow", sys.path)
@@ -129,12 +129,12 @@ def _minimal_metaflow_config() -> dict:
 def _cleanup_minimal_metaflow_config() -> None:
     global _MINIMAL_CONFIG_HOME
     config_home = _MINIMAL_CONFIG_HOME
+    _MINIMAL_CONFIG_HOME = None
     if not config_home:
         return
-    shutil.rmtree(config_home, ignore_errors=True)
     if os.environ.get("METAFLOW_HOME") == config_home:
         os.environ.pop("METAFLOW_HOME", None)
-    _MINIMAL_CONFIG_HOME = None
+    shutil.rmtree(config_home, ignore_errors=True)
 
 
 def _install_minimal_metaflow_config() -> None:
@@ -154,15 +154,23 @@ def _install_minimal_metaflow_config() -> None:
     global _MINIMAL_CONFIG_HOME, _MINIMAL_CONFIG_CLEANUP_REGISTERED
     _cleanup_minimal_metaflow_config()
     config_home = tempfile.mkdtemp(prefix="metaflow-prebuilt-config-")
-    _MINIMAL_CONFIG_HOME = config_home
-    if not _MINIMAL_CONFIG_CLEANUP_REGISTERED:
-        atexit.register(_cleanup_minimal_metaflow_config)
-        _MINIMAL_CONFIG_CLEANUP_REGISTERED = True
-    os.environ["METAFLOW_HOME"] = config_home
+    try:
+        plugin_config = _minimal_metaflow_config()
+        with open(os.path.join(config_home, "config.json"), "w", encoding="utf-8") as f:
+            json.dump(plugin_config, f)
 
-    plugin_config = _minimal_metaflow_config()
-    with open(os.path.join(config_home, "config.json"), "w", encoding="utf-8") as f:
-        json.dump(plugin_config, f)
+        # Publish METAFLOW_HOME only after config.json exists. Deploy-side
+        # parallelism runs separate Docker builds, so these process globals are
+        # not shared across step image builds.
+        _MINIMAL_CONFIG_HOME = config_home
+        if not _MINIMAL_CONFIG_CLEANUP_REGISTERED:
+            atexit.register(_cleanup_minimal_metaflow_config)
+            _MINIMAL_CONFIG_CLEANUP_REGISTERED = True
+        os.environ["METAFLOW_HOME"] = config_home
+        config_home = None
+    finally:
+        if config_home:
+            shutil.rmtree(config_home, ignore_errors=True)
 
 
 def echo_always(msg: str = "", nl: bool = True, err: bool = True, **_: object) -> None:

--- a/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_build_install.py
+++ b/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_build_install.py
@@ -30,6 +30,7 @@ import tarfile
 import tempfile
 import time
 import zipfile
+import atexit
 
 from typing import List, Optional
 
@@ -47,14 +48,65 @@ from typing import List, Optional
 # ever set in the generated Dockerfile.
 os.environ.setdefault("METAFLOW_CONDA_IGNORE_CACHING_DATASTORES", '["local"]')
 
-from metaflow.cli import echo_always
+
+def _truthy(value: str) -> bool:
+    return value.strip().lower() not in ("", "0", "false", "no", "off")
+
+
+def _install_minimal_metaflow_config() -> None:
+    """Keep build-time Metaflow imports from resolving unrelated plugins.
+
+    The base-image Python runs this installer before the target env exists. Some
+    base images intentionally do not include every transitive dependency needed
+    by all Netflix runtime plugins, so plugin resolution must be restricted to
+    the tiny set needed for Conda environment creation.
+    """
+
+    if not _truthy(os.environ.get("METAFLOW_PREBUILT_BUILD_CONTAINER", "0")):
+        return
+    if not _truthy(os.environ.get("METAFLOW_PREBUILT_MINIMAL_PLUGIN_CONFIG", "1")):
+        return
+
+    config_home = tempfile.mkdtemp(prefix="metaflow-prebuilt-config-")
+    atexit.register(lambda: shutil.rmtree(config_home, ignore_errors=True))
+    os.environ["METAFLOW_HOME"] = config_home
+
+    plugin_config = {
+        "METAFLOW_DEFAULT_EVENT_LOGGER": "nullSidecarLogger",
+        "METAFLOW_DEFAULT_MONITOR": "nullSidecarMonitor",
+        "METAFLOW_ENABLED_STEP_DECORATOR": [],
+        "METAFLOW_ENABLED_FLOW_DECORATOR": [],
+        "METAFLOW_ENABLED_ENVIRONMENT": ["nflx", "conda"],
+        "METAFLOW_ENABLED_METADATA_PROVIDER": [],
+        "METAFLOW_ENABLED_DATASTORE": ["local"],
+        "METAFLOW_ENABLED_DATACLIENT": [],
+        "METAFLOW_ENABLED_SECRETS_PROVIDER": [],
+        "METAFLOW_ENABLED_GCP_CLIENT_PROVIDER": [],
+        "METAFLOW_ENABLED_DEPLOYER_IMPL_PROVIDER": [],
+        "METAFLOW_ENABLED_AZURE_CLIENT_PROVIDER": [],
+        "METAFLOW_ENABLED_SIDECAR": [],
+        "METAFLOW_ENABLED_LOGGING_SIDECAR": ["nullSidecarLogger"],
+        "METAFLOW_ENABLED_MONITOR_SIDECAR": ["nullSidecarMonitor"],
+        "METAFLOW_ENABLED_AWS_CLIENT_PROVIDER": [],
+        "METAFLOW_ENABLED_CLI": [],
+        "METAFLOW_ENABLED_RUNNER_CLI": [],
+        "METAFLOW_ENABLED_TL_PLUGIN": [],
+    }
+    with open(os.path.join(config_home, "config.json"), "w", encoding="utf-8") as f:
+        json.dump(plugin_config, f)
+
+
+def echo_always(msg: str = "", nl: bool = True, err: bool = True, **_: object) -> None:
+    print(msg, end="\n" if nl else "", file=sys.stderr if err else sys.stdout)
+
+
+_install_minimal_metaflow_config()
 
 try:
+    from metaflow.metaflow_config import DATASTORE_LOCAL_DIR, CONDA_MAGIC_FILE_V2
+    from metaflow.packaging_sys import ContentType, MetaflowCodeContent
     from metaflow_extensions.netflixext.plugins.conda.conda import Conda
     from metaflow_extensions.netflixext.plugins.conda.env_descr import EnvID
-    from metaflow_extensions.netflixext.plugins.conda.remote_bootstrap import (
-        setup_conda_manifest,
-    )
     from metaflow_extensions.netflixext.plugins.conda.utils import (
         CondaException,
         arch_id,
@@ -90,6 +142,20 @@ _SETUPTOOLS_CHECK = (
     "    sys.exit(3)\n"
     "sys.exit(0 if major < 82 else 4)\n"
 )
+
+
+def setup_conda_manifest() -> None:
+    manifest_folder = os.path.join(os.getcwd(), DATASTORE_LOCAL_DIR)
+    os.makedirs(manifest_folder, exist_ok=True)
+    path_to_manifest = MetaflowCodeContent.get_filename(
+        CONDA_MAGIC_FILE_V2, ContentType.OTHER_CONTENT
+    )
+    if path_to_manifest is None:
+        raise RuntimeError(
+            "Cannot find the conda manifest file %s in the package"
+            % CONDA_MAGIC_FILE_V2
+        )
+    shutil.move(path_to_manifest, os.path.join(manifest_folder, CONDA_MAGIC_FILE_V2))
 
 
 def _parse_build_system_requires(text: str) -> List[str]:

--- a/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_build_install.py
+++ b/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_build_install.py
@@ -31,6 +31,8 @@ import tempfile
 import time
 import zipfile
 import atexit
+import ast
+import importlib.machinery
 
 from typing import List, Optional
 
@@ -55,6 +57,73 @@ def _truthy(value: str) -> bool:
 
 _MINIMAL_CONFIG_HOME: Optional[str] = None
 _MINIMAL_CONFIG_CLEANUP_REGISTERED = False
+_MINIMAL_EVENT_LOGGER = "nullSidecarLogger"
+_MINIMAL_MONITOR = "nullSidecarMonitor"
+_MINIMAL_PLUGIN_ALLOWLIST = {
+    "ENVIRONMENT": ("nflx", "conda"),
+    "DATASTORE": ("local",),
+    "LOGGING_SIDECAR": (_MINIMAL_EVENT_LOGGER,),
+    "MONITOR_SIDECAR": (_MINIMAL_MONITOR,),
+}
+
+
+def _metaflow_plugin_categories() -> List[str]:
+    """Return Metaflow plugin categories without importing Metaflow.
+
+    This module writes ``METAFLOW_HOME/config.json`` before importing
+    ``metaflow``. Importing ``metaflow.extension_support.plugins`` directly would
+    execute Metaflow's package init too early, so read the installed source file
+    and parse the ``_plugin_categories`` literal instead.
+    """
+
+    spec = importlib.machinery.PathFinder.find_spec("metaflow", sys.path)
+    locations = list(spec.submodule_search_locations or []) if spec else []
+    if not locations:
+        raise RuntimeError("Cannot locate installed metaflow package")
+
+    plugins_path = os.path.join(locations[0], "extension_support", "plugins.py")
+    try:
+        with open(plugins_path, encoding="utf-8") as f:
+            tree = ast.parse(f.read(), filename=plugins_path)
+    except OSError as e:
+        raise RuntimeError("Cannot read Metaflow plugin categories: %s" % e) from e
+
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == "_plugin_categories"
+            for target in node.targets
+        ):
+            continue
+        if not isinstance(node.value, ast.Dict):
+            break
+        categories: List[str] = []
+        for key in node.value.keys:
+            if not isinstance(key, ast.Constant) or not isinstance(key.value, str):
+                raise RuntimeError(
+                    "Metaflow _plugin_categories contains a non-string key"
+                )
+            categories.append(key.value.upper())
+        return categories
+
+    raise RuntimeError("Cannot find Metaflow _plugin_categories")
+
+
+def _minimal_metaflow_config() -> dict:
+    categories = _metaflow_plugin_categories()
+    config = {
+        "METAFLOW_DEFAULT_EVENT_LOGGER": _MINIMAL_EVENT_LOGGER,
+        "METAFLOW_DEFAULT_MONITOR": _MINIMAL_MONITOR,
+    }
+    config.update(
+        {
+            "METAFLOW_ENABLED_%s"
+            % category: list(_MINIMAL_PLUGIN_ALLOWLIST.get(category, ()))
+            for category in categories
+        }
+    )
+    return config
 
 
 def _cleanup_minimal_metaflow_config() -> None:
@@ -91,27 +160,7 @@ def _install_minimal_metaflow_config() -> None:
         _MINIMAL_CONFIG_CLEANUP_REGISTERED = True
     os.environ["METAFLOW_HOME"] = config_home
 
-    plugin_config = {
-        "METAFLOW_DEFAULT_EVENT_LOGGER": "nullSidecarLogger",
-        "METAFLOW_DEFAULT_MONITOR": "nullSidecarMonitor",
-        "METAFLOW_ENABLED_STEP_DECORATOR": [],
-        "METAFLOW_ENABLED_FLOW_DECORATOR": [],
-        "METAFLOW_ENABLED_ENVIRONMENT": ["nflx", "conda"],
-        "METAFLOW_ENABLED_METADATA_PROVIDER": [],
-        "METAFLOW_ENABLED_DATASTORE": ["local"],
-        "METAFLOW_ENABLED_DATACLIENT": [],
-        "METAFLOW_ENABLED_SECRETS_PROVIDER": [],
-        "METAFLOW_ENABLED_GCP_CLIENT_PROVIDER": [],
-        "METAFLOW_ENABLED_DEPLOYER_IMPL_PROVIDER": [],
-        "METAFLOW_ENABLED_AZURE_CLIENT_PROVIDER": [],
-        "METAFLOW_ENABLED_SIDECAR": [],
-        "METAFLOW_ENABLED_LOGGING_SIDECAR": ["nullSidecarLogger"],
-        "METAFLOW_ENABLED_MONITOR_SIDECAR": ["nullSidecarMonitor"],
-        "METAFLOW_ENABLED_AWS_CLIENT_PROVIDER": [],
-        "METAFLOW_ENABLED_CLI": [],
-        "METAFLOW_ENABLED_RUNNER_CLI": [],
-        "METAFLOW_ENABLED_TL_PLUGIN": [],
-    }
+    plugin_config = _minimal_metaflow_config()
     with open(os.path.join(config_home, "config.json"), "w", encoding="utf-8") as f:
         json.dump(plugin_config, f)
 

--- a/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_build_install.py
+++ b/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_build_install.py
@@ -53,6 +53,21 @@ def _truthy(value: str) -> bool:
     return value.strip().lower() not in ("", "0", "false", "no", "off")
 
 
+_MINIMAL_CONFIG_HOME: Optional[str] = None
+_MINIMAL_CONFIG_CLEANUP_REGISTERED = False
+
+
+def _cleanup_minimal_metaflow_config() -> None:
+    global _MINIMAL_CONFIG_HOME
+    config_home = _MINIMAL_CONFIG_HOME
+    if not config_home:
+        return
+    shutil.rmtree(config_home, ignore_errors=True)
+    if os.environ.get("METAFLOW_HOME") == config_home:
+        os.environ.pop("METAFLOW_HOME", None)
+    _MINIMAL_CONFIG_HOME = None
+
+
 def _install_minimal_metaflow_config() -> None:
     """Keep build-time Metaflow imports from resolving unrelated plugins.
 
@@ -67,8 +82,13 @@ def _install_minimal_metaflow_config() -> None:
     if not _truthy(os.environ.get("METAFLOW_PREBUILT_MINIMAL_PLUGIN_CONFIG", "1")):
         return
 
+    global _MINIMAL_CONFIG_HOME, _MINIMAL_CONFIG_CLEANUP_REGISTERED
+    _cleanup_minimal_metaflow_config()
     config_home = tempfile.mkdtemp(prefix="metaflow-prebuilt-config-")
-    atexit.register(lambda: shutil.rmtree(config_home, ignore_errors=True))
+    _MINIMAL_CONFIG_HOME = config_home
+    if not _MINIMAL_CONFIG_CLEANUP_REGISTERED:
+        atexit.register(_cleanup_minimal_metaflow_config)
+        _MINIMAL_CONFIG_CLEANUP_REGISTERED = True
     os.environ["METAFLOW_HOME"] = config_home
 
     plugin_config = {
@@ -592,15 +612,26 @@ def install_env(req_id: str, full_id: str) -> str:
     return env_path
 
 
-if __name__ == "__main__":
-    if len(sys.argv) != 3:
+def main(argv: Optional[List[str]] = None) -> int:
+    args = sys.argv if argv is None else argv
+    if len(args) != 3:
         print(
             "Usage: python -m metaflow_extensions.prebuilt.plugins.conda."
             "prebuilt_build_install <req_id> <full_id>",
             file=sys.stderr,
         )
-        sys.exit(2)
-    path = install_env(sys.argv[1], sys.argv[2])
-    print(path)
-    sys.stdout.flush()
-    os._exit(0)
+        return 2
+    try:
+        path = install_env(args[1], args[2])
+        print(path)
+        sys.stdout.flush()
+        return 0
+    finally:
+        _cleanup_minimal_metaflow_config()
+
+
+if __name__ == "__main__":
+    exit_code = main()
+    if exit_code == 0:
+        os._exit(0)
+    sys.exit(exit_code)

--- a/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_conda_environment.py
+++ b/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_conda_environment.py
@@ -1181,9 +1181,9 @@ def _generate_dockerfile(
     bootstrap_command = (
         "BOOTSTRAP=$(mktemp -d) && "
         "(python -c 'import requests' >/dev/null 2>&1 || "
-        "(python -m pip --version >/dev/null 2>&1 || "
+        "((python -m pip --version >/dev/null 2>&1 || "
         "python -m ensurepip --upgrade) && "
-        "%s) && "
+        "%s)) && "
         "METAFLOW_PREBUILT_BUILD_CONTAINER=1 "
         'PYTHONPATH="$BOOTSTRAP:$PYTHONPATH" %s && '
         'rm -rf "$BOOTSTRAP"' % (bootstrap_pip_command, build_install_command)

--- a/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_conda_environment.py
+++ b/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_conda_environment.py
@@ -1173,11 +1173,11 @@ def _generate_dockerfile(
         "(python -m pip --version >/dev/null 2>&1 || "
         "python -m ensurepip --upgrade) && "
         "python -m pip install --disable-pip-version-check --no-cache-dir "
-        "--index-url https://pypi.netflix.net/simple --target \"$BOOTSTRAP\" "
+        '--index-url https://pypi.netflix.net/simple --target "$BOOTSTRAP" '
         "requests) && "
         "METAFLOW_PREBUILT_BUILD_CONTAINER=1 "
-        "PYTHONPATH=\"$BOOTSTRAP:$PYTHONPATH\" %s && "
-        "rm -rf \"$BOOTSTRAP\"" % build_install_command
+        'PYTHONPATH="$BOOTSTRAP:$PYTHONPATH" %s && '
+        'rm -rf "$BOOTSTRAP"' % build_install_command
     )
     cleanup_command = "rm -rf %s/pkgs %s/conda-bld /root/.cache/pip" % (
         PREBUILT_MAMBA_ROOT_PREFIX,
@@ -1203,8 +1203,7 @@ def _generate_dockerfile(
                 % (_DEFERRED_WHEELS_CONTEXT_DIR, _DEFERRED_WHEELS_CONTAINER_DIR)
             )
         lines.append(
-            "RUN %s %s && %s"
-            % (" ".join(mounts), bootstrap_command, cleanup_command)
+            "RUN %s %s && %s" % (" ".join(mounts), bootstrap_command, cleanup_command)
         )
     else:
         # COPY the current deferred-builds hand-off (ALWAYS - this overwrites

--- a/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_conda_environment.py
+++ b/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_conda_environment.py
@@ -807,11 +807,13 @@ class PrebuiltCondaEnvironment(CondaEnvironment):
             dockerfile_build_options=build_options,
         )
         context_files.update(embedded_wheel_files)
-        install_support_blob, runtime_code_blob = (
-            _split_code_package_for_prebuilt_build(code_package_blob)
+        context_files[_INSTALL_SUPPORT_TARBALL_NAME] = _build_install_support_package(
+            code_package_blob
         )
-        context_files[_INSTALL_SUPPORT_TARBALL_NAME] = install_support_blob
-        context_files[_CODE_PACKAGE_TARBALL_NAME] = runtime_code_blob
+        # Keep the runtime package byte-for-byte identical to MetaflowPackage
+        # output. The support tarball above is only an early, cache-friendly
+        # extract for the build-time installer.
+        context_files[_CODE_PACKAGE_TARBALL_NAME] = code_package_blob
 
         success = build_svc.build_and_push(
             dockerfile,
@@ -950,38 +952,33 @@ def _write_deterministic_gzip_tar(
     return out.getvalue()
 
 
-def _split_code_package_for_prebuilt_build(
+def _build_install_support_package(
     code_package_blob: bytes,
-) -> Tuple[bytes, bytes]:
-    """Split env-install support files from runtime user code.
+) -> bytes:
+    """Return the env-install support subset of a Metaflow code package.
 
     The build-time installer only needs packaged Metaflow/extension modules plus
     ``OTHER_CONTENT`` metadata. Extracting that stable subset before the env
     install lets Docker build backends reuse the expensive env layer when only
-    flow code changes. The runtime tarball is extracted after the env install,
-    preserving the final image's complete package tree.
+    flow code changes. The full original code package is still extracted after
+    the env install, preserving the final image's complete package tree exactly.
     """
     support_members: List[Tuple[tarfile.TarInfo, bytes]] = []
-    runtime_members: List[Tuple[tarfile.TarInfo, bytes]] = []
     with tarfile.open(fileobj=io.BytesIO(code_package_blob), mode="r:*") as src:
         for member in src.getmembers():
             if member.isdir():
                 continue
+            if not _is_install_support_member(member.name):
+                continue
             payload = src.extractfile(member).read() if member.isfile() else b""
-            if _is_install_support_member(member.name):
-                support_members.append((member, payload))
-            else:
-                runtime_members.append((member, payload))
+            support_members.append((member, payload))
 
     if not support_members:
         raise MetaflowException(
-            "Failed to split prebuilt code package: no install-support files found."
+            "Failed to build prebuilt install-support package: no support files found."
         )
 
-    return (
-        _write_deterministic_gzip_tar(support_members),
-        _write_deterministic_gzip_tar(runtime_members),
-    )
+    return _write_deterministic_gzip_tar(support_members)
 
 
 def _gather_embedded_wheels(

--- a/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_conda_environment.py
+++ b/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_conda_environment.py
@@ -543,9 +543,7 @@ class PrebuiltCondaEnvironment(CondaEnvironment):
         # step images build in parallel. The builds themselves run remotely via
         # `newt build-docker --remote`, so local resource pressure is minimal.
         max_workers = int(
-            os.environ.get(
-                "METAFLOW_PREBUILT_BUILD_WORKERS", str(len(unique_specs))
-            )
+            os.environ.get("METAFLOW_PREBUILT_BUILD_WORKERS", str(len(unique_specs)))
         )
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             futures = {
@@ -589,9 +587,9 @@ class PrebuiltCondaEnvironment(CondaEnvironment):
 
             self.__class__._prebuilt_images[image_key] = pull_tag
             self.__class__._prebuilt_env_paths[spec["env_key"]] = env_path
-            self.__class__._prebuilt_env_paths[
-                _step_state_key(spec["step"].name)
-            ] = env_path
+            self.__class__._prebuilt_env_paths[_step_state_key(spec["step"].name)] = (
+                env_path
+            )
 
             pull_config = registry.pull_config(pull_tag)
             found_remote_deco = False

--- a/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_conda_environment.py
+++ b/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_conda_environment.py
@@ -1,11 +1,14 @@
 import atexit
 from contextlib import contextmanager
 import fcntl
+import gzip
+import io
 import json
 import logging
 import os
 import shutil
 import subprocess
+import tarfile
 import tempfile
 import threading
 import time
@@ -63,13 +66,15 @@ logger = logging.getLogger(__name__)
 # Schema version prefix on the image tag. Bump when the Dockerfile shape,
 # bootstrap activation contract, env_path layout, or tag scheme changes in a way
 # that makes pre-existing images at the same env-id incompatible.
+# v31: the generated Dockerfile removes Conda package caches in the same RUN as
+#      env installation, so package archives/extracts never enter the committed
+#      install layer.
 # v30: the generated Dockerfile removes Conda package caches after installing
-#      the runtime env, so exported prebuilt images do not carry build-only
-#      package archives/extracts.
+#      the runtime env.
 # v29: the registry tag now carries a base-image/arch variant suffix (image
 #      identity), so images that share an env but differ by base/arch no longer
 #      collide on one tag.
-PREBUILT_IMAGE_SCHEMA_VERSION = "v30"
+PREBUILT_IMAGE_SCHEMA_VERSION = "v31"
 
 # Docker tag components allow [A-Za-z0-9_.-]; everything else is replaced.
 _TAG_SAFE_CHARS = set(
@@ -86,8 +91,15 @@ PREBUILT_ENVS_DIR = os.path.join(PREBUILT_MAMBA_ROOT_PREFIX, "envs")
 # container — same shape the runtime entry_point uses.
 PREBUILT_BUILD_LOCAL_ROOT = "/opt/metaflow/code-package"
 
-# Name under which the MetaflowPackage tarball lives in the docker build context.
+# Names under which the MetaflowPackage tarballs live in the docker build context.
 _CODE_PACKAGE_TARBALL_NAME = "job.tar"
+_INSTALL_SUPPORT_TARBALL_NAME = "install_support.tar.gz"
+_INSTALL_SUPPORT_PREFIXES = (
+    ".mf_code/metaflow/",
+    ".mf_code/metaflow_extensions/",
+    ".mf_meta/",
+)
+_INSTALL_SUPPORT_FILES = (".mf_install",)
 
 # Wire-format names for the deferred-builds hand-off (schema_version "2"),
 # OWNED by metaflow-prebuilt. Must stay in sync with the container-side
@@ -96,6 +108,14 @@ _DEFERRED_BUILDS_CONTEXT_NAME = "deferred_builds.json"
 _DEFERRED_BUILDS_CONTAINER_PATH = "/app/deferred_builds.json"
 _DEFERRED_WHEELS_CONTEXT_DIR = "deferred_wheels"
 _DEFERRED_WHEELS_CONTAINER_DIR = "/app/deferred_wheels"
+_PREBUILT_REGISTRY_CACHE_ENV = "METAFLOW_PREBUILT_REGISTRY_CACHE"
+
+
+def _env_flag_enabled(name: str, default: bool) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in ("", "0", "false", "no", "off")
 
 
 def _env_path_for(env_id: EnvID) -> str:
@@ -198,21 +218,31 @@ def _env_cache_key(env_id: EnvID) -> str:
 _image_cache_key = _env_cache_key
 
 
-def _image_variant(base_image: str, arch: str) -> str:
+def _tag_safe(value: str) -> str:
+    return "".join(c if c in _TAG_SAFE_CHARS else "_" for c in value)
+
+
+def _image_variant(base_image: str, arch: str, build_identity: str = "") -> str:
     """Discriminator for images that share an env (same req_id/full_id) but are
-    built on a DIFFERENT base image (CPU vs GPU) or for a DIFFERENT target arch.
+    built on a DIFFERENT base image (CPU vs GPU), for a DIFFERENT target arch, or
+    with build-service settings that change image output identity.
 
     Folded into BOTH the in-process image-dedup key and the registry tag so such
     images never collide on one tag — without it, a CPU-first flow could run a
-    GPU step on the CPU base, and a GPU build would overwrite the CPU image at
-    the same registry tag. ``env_id.arch`` is included because the env cache key
-    drops it."""
+    GPU step on the CPU base, and a GPU build or alternate layer encoding would
+    overwrite the CPU/default image at the same registry tag. ``env_id.arch`` is
+    included because the env cache key drops it."""
     import hashlib  # noqa: PLC0415
 
-    safe_arch = "".join(c if c in _TAG_SAFE_CHARS else "_" for c in (arch or "noarch"))
+    safe_arch = _tag_safe(arch or "noarch")
+    safe_build_identity = _tag_safe(build_identity).strip("._-")
     digest = hashlib.sha256(
-        ("%s\x00%s" % (base_image or "", arch or "")).encode("utf-8")
+        ("%s\x00%s\x00%s" % (base_image or "", arch or "", build_identity)).encode(
+            "utf-8"
+        )
     ).hexdigest()[:8]
+    if safe_build_identity:
+        return "%s-%s-%s" % (safe_arch, safe_build_identity[:32], digest)
     return "%s-%s" % (safe_arch, digest)
 
 
@@ -410,9 +440,14 @@ class PrebuiltCondaEnvironment(CondaEnvironment):
         self.__class__._prebuilt_env_paths = {}
 
         registry = ImageRegistry.from_config()
+        build_svc = DockerBuildService.from_config()
+        build_identity = build_svc.image_identity_suffix()
+        if not isinstance(build_identity, str):
+            build_identity = ""
 
         # --- Phase 1: Collect build specs for all remote steps (sequential) ---
         step_specs = []
+        base_identity_cache: Dict[Tuple[str, str], str] = {}
         for step in self._flow:
             env_id = self.get_env_id(cast(Conda, self.conda), step.name)
             if env_id is None:
@@ -463,14 +498,18 @@ class PrebuiltCondaEnvironment(CondaEnvironment):
                     "(for GPU steps) or METAFLOW_PREBUILT_BASE_IMAGE."
                 )
             arch = getattr(env_id, "arch", "")
-            base_identity = registry.base_image_identity(base_image, arch)
+            base_identity_key = (base_image, arch)
+            base_identity = base_identity_cache.get(base_identity_key)
+            if base_identity is None:
+                base_identity = registry.base_image_identity(base_image, arch)
+                base_identity_cache[base_identity_key] = base_identity
             if base_identity != base_image:
                 echo(
                     "    Base image resolved for prebuilt tag: %s -> %s"
                     % (base_image, base_identity)
                 )
             build_base_image = base_identity or base_image
-            variant = _image_variant(build_base_image, arch)
+            variant = _image_variant(build_base_image, arch, build_identity)
             image_key = _image_dedup_key(env_key, variant)
             env_path = (
                 _env_path_for_named(named_alias)
@@ -495,20 +534,10 @@ class PrebuiltCondaEnvironment(CondaEnvironment):
             self.__class__._persist_prebuilt_state()
             return
 
-        # --- Phase 2: Build the MetaflowPackage code tarball once, shared
-        #     across all image builds (it is flow-level, identical for every
-        #     step and expensive to rebuild N times). ---
-        try:
-            code_package_blob = _build_metaflow_code_package(self, echo)
-        except Exception as e:
-            raise MetaflowException(
-                "Failed to build metaflow code package: %s" % e
-            ) from e
-
-        # --- Phase 3: Build unique images concurrently.
+        # --- Phase 2: Build unique images concurrently.
         #     Steps that share the same image_key (same env + base/arch) are
         #     deduped — only the first spec triggers a build; the result is
-        #     reused by all steps with that key in Phase 4. ---
+        #     reused by all steps with that key in Phase 3. ---
         unique_specs: Dict[str, dict] = {}
         for spec in step_specs:
             if spec["image_key"] not in unique_specs:
@@ -519,6 +548,23 @@ class PrebuiltCondaEnvironment(CondaEnvironment):
         def _locked_echo(msg: str) -> None:
             with echo_lock:
                 echo(msg)
+
+        # The code package is flow-level and identical for every step image. Build
+        # it lazily so all-registry-hit deploys skip packaging entirely, but share
+        # the bytes across concurrent misses so it is still built at most once.
+        code_package_lock = threading.Lock()
+        code_package: Dict[str, bytes] = {}
+
+        def _shared_code_package_blob() -> bytes:
+            blob = code_package.get("blob")
+            if blob is not None:
+                return blob
+            with code_package_lock:
+                blob = code_package.get("blob")
+                if blob is None:
+                    blob = _build_metaflow_code_package(self, _locked_echo)
+                    code_package["blob"] = blob
+                return blob
 
         # keyed by image_key; None means the build failed.
         image_results: Dict[str, Optional[Tuple[str, str]]] = {
@@ -534,7 +580,7 @@ class PrebuiltCondaEnvironment(CondaEnvironment):
                 base_image=spec["base_image"],
                 variant=spec["variant"],
                 named_alias=spec["named_alias"],
-                code_package_blob=code_package_blob,
+                code_package_blob_supplier=_shared_code_package_blob,
             )
             image_results[image_key] = result
 
@@ -542,9 +588,17 @@ class PrebuiltCondaEnvironment(CondaEnvironment):
         # Default: unbounded (one worker per unique image) so all independent
         # step images build in parallel. The builds themselves run remotely via
         # `newt build-docker --remote`, so local resource pressure is minimal.
-        max_workers = int(
-            os.environ.get("METAFLOW_PREBUILT_BUILD_WORKERS", str(len(unique_specs)))
-        )
+        configured_workers = os.environ.get("METAFLOW_PREBUILT_BUILD_WORKERS")
+        try:
+            max_workers = (
+                int(configured_workers)
+                if configured_workers is not None
+                else len(unique_specs)
+            )
+        except ValueError:
+            max_workers = len(unique_specs)
+        if max_workers <= 0:
+            max_workers = len(unique_specs)
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             futures = {
                 executor.submit(_build_one, ik, spec): ik
@@ -571,12 +625,12 @@ class PrebuiltCondaEnvironment(CondaEnvironment):
                 % len(failed_keys)
             )
 
-        # --- Phase 4: Update class state and rewrite step decorators
+        # --- Phase 3: Update class state and rewrite step decorators
         #     (sequential — decorator mutation is not thread-safe). ---
         for spec in step_specs:
             image_key = spec["image_key"]
             result = image_results[image_key]
-            assert result is not None  # guaranteed: Phase 3 raised on all failures
+            assert result is not None  # guaranteed: failed_keys raised above.
             pull_tag, env_path = result
 
             self.__class__._prebuilt_images[image_key] = pull_tag
@@ -618,6 +672,7 @@ class PrebuiltCondaEnvironment(CondaEnvironment):
         variant: str,
         named_alias: Optional[str] = None,
         code_package_blob: Optional[bytes] = None,
+        code_package_blob_supplier: Optional[Callable[[], bytes]] = None,
     ) -> Optional[Tuple[str, str]]:
         """Build the prebuilt image and return ``(pull_tag, env_path)`` or
         ``None`` on failure. ``base_image`` and ``variant`` are resolved by the
@@ -659,13 +714,26 @@ class PrebuiltCondaEnvironment(CondaEnvironment):
         # this exact env/base/arch image, reuse it instead of rebuilding and
         # repushing the large conda layer. Named env tags remain mutable and must
         # rebuild so a new deploy can intentionally move the alias.
-        if named_alias is None and registry.image_exists(push_tag):
+        registry_cache_enabled = _env_flag_enabled(_PREBUILT_REGISTRY_CACHE_ENV, True)
+        if (
+            named_alias is None
+            and registry_cache_enabled
+            and registry.image_exists(push_tag)
+        ):
             echo("    Reusing existing prebuilt image: %s" % push_tag)
             return pull_tag, env_path
+        if named_alias is None and not registry_cache_enabled:
+            echo(
+                "    Registry prebuilt image reuse disabled by %s; rebuilding: %s"
+                % (_PREBUILT_REGISTRY_CACHE_ENV, push_tag)
+            )
 
         if code_package_blob is None:
             try:
-                code_package_blob = _build_metaflow_code_package(self, echo)
+                if code_package_blob_supplier is not None:
+                    code_package_blob = code_package_blob_supplier()
+                else:
+                    code_package_blob = _build_metaflow_code_package(self, echo)
             except Exception as e:
                 echo("    ERROR: failed to build metaflow code package: %s" % e)
                 return None
@@ -730,7 +798,11 @@ class PrebuiltCondaEnvironment(CondaEnvironment):
             dockerfile_build_options=build_options,
         )
         context_files.update(embedded_wheel_files)
-        context_files[_CODE_PACKAGE_TARBALL_NAME] = code_package_blob
+        install_support_blob, runtime_code_blob = (
+            _split_code_package_for_prebuilt_build(code_package_blob)
+        )
+        context_files[_INSTALL_SUPPORT_TARBALL_NAME] = install_support_blob
+        context_files[_CODE_PACKAGE_TARBALL_NAME] = runtime_code_blob
 
         success = build_svc.build_and_push(
             dockerfile,
@@ -839,6 +911,58 @@ def _build_metaflow_code_package(
         raise RuntimeError("MetaflowPackage blob is empty")
     echo("    Code package: %.1f MB" % (len(data) / (1024 * 1024)))
     return data
+
+
+def _is_install_support_member(name: str) -> bool:
+    return name in _INSTALL_SUPPORT_FILES or name.startswith(_INSTALL_SUPPORT_PREFIXES)
+
+
+def _write_deterministic_gzip_tar(
+    members: List[Tuple[tarfile.TarInfo, bytes]],
+) -> bytes:
+    out = io.BytesIO()
+    with gzip.GzipFile(fileobj=out, mode="wb", mtime=0) as gz:
+        with tarfile.open(fileobj=gz, mode="w") as tar:
+            for member, payload in members:
+                if member.isfile():
+                    tar.addfile(member, io.BytesIO(payload))
+                else:
+                    tar.addfile(member)
+    return out.getvalue()
+
+
+def _split_code_package_for_prebuilt_build(
+    code_package_blob: bytes,
+) -> Tuple[bytes, bytes]:
+    """Split env-install support files from runtime user code.
+
+    The build-time installer only needs packaged Metaflow/extension modules plus
+    ``OTHER_CONTENT`` metadata. Extracting that stable subset before the env
+    install lets Docker/Newt reuse the expensive env layer when only flow code
+    changes. The runtime tarball is extracted after the env install, preserving
+    the final image's complete package tree.
+    """
+    support_members: List[Tuple[tarfile.TarInfo, bytes]] = []
+    runtime_members: List[Tuple[tarfile.TarInfo, bytes]] = []
+    with tarfile.open(fileobj=io.BytesIO(code_package_blob), mode="r:*") as src:
+        for member in src.getmembers():
+            if member.isdir():
+                continue
+            payload = src.extractfile(member).read() if member.isfile() else b""
+            if _is_install_support_member(member.name):
+                support_members.append((member, payload))
+            else:
+                runtime_members.append((member, payload))
+
+    if not support_members:
+        raise MetaflowException(
+            "Failed to split prebuilt code package: no install-support files found."
+        )
+
+    return (
+        _write_deterministic_gzip_tar(support_members),
+        _write_deterministic_gzip_tar(runtime_members),
+    )
 
 
 def _gather_embedded_wheels(
@@ -1011,12 +1135,13 @@ def _generate_dockerfile(
         "ENV CONDA_ENVS_DIRS=%s" % PREBUILT_ENVS_DIR,
         "",
         "RUN mkdir -p %s" % PREBUILT_BUILD_LOCAL_ROOT,
-        "COPY %s /tmp/%s" % (_CODE_PACKAGE_TARBALL_NAME, _CODE_PACKAGE_TARBALL_NAME),
+        "COPY %s /tmp/%s"
+        % (_INSTALL_SUPPORT_TARBALL_NAME, _INSTALL_SUPPORT_TARBALL_NAME),
         "RUN tar -xzf /tmp/%s -C %s && rm /tmp/%s"
         % (
-            _CODE_PACKAGE_TARBALL_NAME,
+            _INSTALL_SUPPORT_TARBALL_NAME,
             PREBUILT_BUILD_LOCAL_ROOT,
-            _CODE_PACKAGE_TARBALL_NAME,
+            _INSTALL_SUPPORT_TARBALL_NAME,
         ),
         "WORKDIR %s" % PREBUILT_BUILD_LOCAL_ROOT,
         "",
@@ -1028,6 +1153,10 @@ def _generate_dockerfile(
         build_install_module,
         env_id.req_id,
         env_id.full_id,
+    )
+    cleanup_command = "rm -rf %s/pkgs %s/conda-bld /root/.cache/pip" % (
+        PREBUILT_MAMBA_ROOT_PREFIX,
+        PREBUILT_MAMBA_ROOT_PREFIX,
     )
 
     if options.buildkit_deferred_input_mounts:
@@ -1048,7 +1177,10 @@ def _generate_dockerfile(
                 "--mount=type=bind,source=%s,target=%s,readonly"
                 % (_DEFERRED_WHEELS_CONTEXT_DIR, _DEFERRED_WHEELS_CONTAINER_DIR)
             )
-        lines.append("RUN %s %s" % (" ".join(mounts), build_install_command))
+        lines.append(
+            "RUN %s %s && %s"
+            % (" ".join(mounts), build_install_command, cleanup_command)
+        )
     else:
         # COPY the current deferred-builds hand-off (ALWAYS - this overwrites
         # any stale hand-off inherited from the base image) and any embedded
@@ -1062,10 +1194,18 @@ def _generate_dockerfile(
                 "COPY %s %s"
                 % (_DEFERRED_WHEELS_CONTEXT_DIR, _DEFERRED_WHEELS_CONTAINER_DIR)
             )
-        lines.append("RUN %s" % build_install_command)
-    lines.append(
-        "RUN rm -rf %s/pkgs %s/conda-bld /root/.cache/pip"
-        % (PREBUILT_MAMBA_ROOT_PREFIX, PREBUILT_MAMBA_ROOT_PREFIX)
+        lines.append("RUN %s && %s" % (build_install_command, cleanup_command))
+    lines.extend(
+        [
+            "COPY %s /tmp/%s"
+            % (_CODE_PACKAGE_TARBALL_NAME, _CODE_PACKAGE_TARBALL_NAME),
+            "RUN tar -xzf /tmp/%s -C %s && rm /tmp/%s"
+            % (
+                _CODE_PACKAGE_TARBALL_NAME,
+                PREBUILT_BUILD_LOCAL_ROOT,
+                _CODE_PACKAGE_TARBALL_NAME,
+            ),
+        ]
     )
 
     if named_alias is not None:

--- a/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_conda_environment.py
+++ b/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_conda_environment.py
@@ -66,6 +66,9 @@ logger = logging.getLogger(__name__)
 # Schema version prefix on the image tag. Bump when the Dockerfile shape,
 # bootstrap activation contract, env_path layout, or tag scheme changes in a way
 # that makes pre-existing images at the same env-id incompatible.
+# v32: the generated Dockerfile bootstraps tiny build-time Python dependencies
+#      when the base image does not provide them, then removes that bootstrap
+#      target in the same RUN as env installation.
 # v31: the generated Dockerfile removes Conda package caches in the same RUN as
 #      env installation, so package archives/extracts never enter the committed
 #      install layer.
@@ -74,7 +77,7 @@ logger = logging.getLogger(__name__)
 # v29: the registry tag now carries a base-image/arch variant suffix (image
 #      identity), so images that share an env but differ by base/arch no longer
 #      collide on one tag.
-PREBUILT_IMAGE_SCHEMA_VERSION = "v31"
+PREBUILT_IMAGE_SCHEMA_VERSION = "v32"
 
 # Docker tag components allow [A-Za-z0-9_.-]; everything else is replaced.
 _TAG_SAFE_CHARS = set(
@@ -924,10 +927,20 @@ def _write_deterministic_gzip_tar(
     with gzip.GzipFile(fileobj=out, mode="wb", mtime=0) as gz:
         with tarfile.open(fileobj=gz, mode="w") as tar:
             for member, payload in members:
+                normalized = tarfile.TarInfo(member.name)
+                normalized.size = len(payload) if member.isfile() else 0
+                normalized.mode = member.mode
+                normalized.type = member.type
+                normalized.linkname = member.linkname
+                normalized.mtime = 0
+                normalized.uid = 0
+                normalized.gid = 0
+                normalized.uname = ""
+                normalized.gname = ""
                 if member.isfile():
-                    tar.addfile(member, io.BytesIO(payload))
+                    tar.addfile(normalized, io.BytesIO(payload))
                 else:
-                    tar.addfile(member)
+                    tar.addfile(normalized)
     return out.getvalue()
 
 
@@ -1154,6 +1167,18 @@ def _generate_dockerfile(
         env_id.req_id,
         env_id.full_id,
     )
+    bootstrap_command = (
+        "BOOTSTRAP=$(mktemp -d) && "
+        "(python -c 'import requests' >/dev/null 2>&1 || "
+        "(python -m pip --version >/dev/null 2>&1 || "
+        "python -m ensurepip --upgrade) && "
+        "python -m pip install --disable-pip-version-check --no-cache-dir "
+        "--index-url https://pypi.netflix.net/simple --target \"$BOOTSTRAP\" "
+        "requests) && "
+        "METAFLOW_PREBUILT_BUILD_CONTAINER=1 "
+        "PYTHONPATH=\"$BOOTSTRAP:$PYTHONPATH\" %s && "
+        "rm -rf \"$BOOTSTRAP\"" % build_install_command
+    )
     cleanup_command = "rm -rf %s/pkgs %s/conda-bld /root/.cache/pip" % (
         PREBUILT_MAMBA_ROOT_PREFIX,
         PREBUILT_MAMBA_ROOT_PREFIX,
@@ -1179,7 +1204,7 @@ def _generate_dockerfile(
             )
         lines.append(
             "RUN %s %s && %s"
-            % (" ".join(mounts), build_install_command, cleanup_command)
+            % (" ".join(mounts), bootstrap_command, cleanup_command)
         )
     else:
         # COPY the current deferred-builds hand-off (ALWAYS - this overwrites
@@ -1194,7 +1219,7 @@ def _generate_dockerfile(
                 "COPY %s %s"
                 % (_DEFERRED_WHEELS_CONTEXT_DIR, _DEFERRED_WHEELS_CONTAINER_DIR)
             )
-        lines.append("RUN %s && %s" % (build_install_command, cleanup_command))
+        lines.append("RUN %s && %s" % (bootstrap_command, cleanup_command))
     lines.extend(
         [
             "COPY %s /tmp/%s"

--- a/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_conda_environment.py
+++ b/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_conda_environment.py
@@ -576,13 +576,7 @@ class PrebuiltCondaEnvironment(CondaEnvironment):
         for spec in step_specs:
             image_key = spec["image_key"]
             result = image_results[image_key]
-            # Should never be None here — failures raised above.
-            if result is None:
-                raise MetaflowException(
-                    "Prebuilt image build failed for step %r. "
-                    "--environment=prebuilt does not fall back to "
-                    "standard conda." % spec["step"].name
-                )
+            assert result is not None  # guaranteed: Phase 3 raised on all failures
             pull_tag, env_path = result
 
             self.__class__._prebuilt_images[image_key] = pull_tag

--- a/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_conda_environment.py
+++ b/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_conda_environment.py
@@ -6,6 +6,7 @@ import io
 import json
 import logging
 import os
+import shlex
 import shutil
 import subprocess
 import tarfile
@@ -956,9 +957,9 @@ def _split_code_package_for_prebuilt_build(
 
     The build-time installer only needs packaged Metaflow/extension modules plus
     ``OTHER_CONTENT`` metadata. Extracting that stable subset before the env
-    install lets Docker/Newt reuse the expensive env layer when only flow code
-    changes. The runtime tarball is extracted after the env install, preserving
-    the final image's complete package tree.
+    install lets Docker build backends reuse the expensive env layer when only
+    flow code changes. The runtime tarball is extracted after the env install,
+    preserving the final image's complete package tree.
     """
     support_members: List[Tuple[tarfile.TarInfo, bytes]] = []
     runtime_members: List[Tuple[tarfile.TarInfo, bytes]] = []
@@ -1167,6 +1168,14 @@ def _generate_dockerfile(
     ]
 
     options = dockerfile_build_options or DockerfileBuildOptions()
+    bootstrap_pip_options = " ".join(
+        shlex.quote(arg) for arg in options.bootstrap_pip_install_options
+    )
+    bootstrap_pip_command = (
+        "python -m pip install --disable-pip-version-check --no-cache-dir "
+        + (bootstrap_pip_options + " " if bootstrap_pip_options else "")
+        + '--target "$BOOTSTRAP" requests'
+    )
     build_install_command = "python -m %s.prebuilt_build_install %s %s" % (
         build_install_module,
         env_id.req_id,
@@ -1177,12 +1186,10 @@ def _generate_dockerfile(
         "(python -c 'import requests' >/dev/null 2>&1 || "
         "(python -m pip --version >/dev/null 2>&1 || "
         "python -m ensurepip --upgrade) && "
-        "python -m pip install --disable-pip-version-check --no-cache-dir "
-        '--index-url https://pypi.netflix.net/simple --target "$BOOTSTRAP" '
-        "requests) && "
+        "%s) && "
         "METAFLOW_PREBUILT_BUILD_CONTAINER=1 "
         'PYTHONPATH="$BOOTSTRAP:$PYTHONPATH" %s && '
-        'rm -rf "$BOOTSTRAP"' % build_install_command
+        'rm -rf "$BOOTSTRAP"' % (bootstrap_pip_command, build_install_command)
     )
     cleanup_command = "rm -rf %s/pkgs %s/conda-bld /root/.cache/pip" % (
         PREBUILT_MAMBA_ROOT_PREFIX,

--- a/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_conda_environment.py
+++ b/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_conda_environment.py
@@ -7,7 +7,9 @@ import os
 import shutil
 import subprocess
 import tempfile
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
@@ -409,6 +411,8 @@ class PrebuiltCondaEnvironment(CondaEnvironment):
 
         registry = ImageRegistry.from_config()
 
+        # --- Phase 1: Collect build specs for all remote steps (sequential) ---
+        step_specs = []
         for step in self._flow:
             env_id = self.get_env_id(cast(Conda, self.conda), step.name)
             if env_id is None:
@@ -474,35 +478,124 @@ class PrebuiltCondaEnvironment(CondaEnvironment):
                 else _env_path_for(env_id)
             )
 
-            if image_key in self.__class__._prebuilt_images:
-                pull_tag = self.__class__._prebuilt_images[image_key]
-            else:
-                result = self._get_or_build_image(
-                    env_id,
-                    step,
-                    echo,
-                    registry,
-                    base_image=build_base_image,
-                    variant=variant,
-                    named_alias=named_alias,
-                )
-                if result is None:
-                    raise MetaflowException(
-                        "Prebuilt image build failed for step %r. "
-                        "--environment=prebuilt does not fall back to "
-                        "standard conda." % step.name
+            step_specs.append(
+                {
+                    "step": step,
+                    "env_id": env_id,
+                    "env_key": env_key,
+                    "env_path": env_path,
+                    "named_alias": named_alias,
+                    "image_key": image_key,
+                    "base_image": build_base_image,
+                    "variant": variant,
+                }
+            )
+
+        if not step_specs:
+            self.__class__._persist_prebuilt_state()
+            return
+
+        # --- Phase 2: Build the MetaflowPackage code tarball once, shared
+        #     across all image builds (it is flow-level, identical for every
+        #     step and expensive to rebuild N times). ---
+        try:
+            code_package_blob = _build_metaflow_code_package(self, echo)
+        except Exception as e:
+            raise MetaflowException(
+                "Failed to build metaflow code package: %s" % e
+            ) from e
+
+        # --- Phase 3: Build unique images concurrently.
+        #     Steps that share the same image_key (same env + base/arch) are
+        #     deduped — only the first spec triggers a build; the result is
+        #     reused by all steps with that key in Phase 4. ---
+        unique_specs: Dict[str, dict] = {}
+        for spec in step_specs:
+            if spec["image_key"] not in unique_specs:
+                unique_specs[spec["image_key"]] = spec
+
+        echo_lock = threading.Lock()
+
+        def _locked_echo(msg: str) -> None:
+            with echo_lock:
+                echo(msg)
+
+        # keyed by image_key; None means the build failed.
+        image_results: Dict[str, Optional[Tuple[str, str]]] = {
+            ik: None for ik in unique_specs
+        }
+
+        def _build_one(image_key: str, spec: dict) -> None:
+            result = self._get_or_build_image(
+                spec["env_id"],
+                spec["step"],
+                _locked_echo,
+                registry,
+                base_image=spec["base_image"],
+                variant=spec["variant"],
+                named_alias=spec["named_alias"],
+                code_package_blob=code_package_blob,
+            )
+            image_results[image_key] = result
+
+        # METAFLOW_PREBUILT_BUILD_WORKERS caps concurrent image builds.
+        # Default: unbounded (one worker per unique image) so all independent
+        # step images build in parallel. The builds themselves run remotely via
+        # `newt build-docker --remote`, so local resource pressure is minimal.
+        max_workers = int(
+            os.environ.get(
+                "METAFLOW_PREBUILT_BUILD_WORKERS", str(len(unique_specs))
+            )
+        )
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = {
+                executor.submit(_build_one, ik, spec): ik
+                for ik, spec in unique_specs.items()
+            }
+            failed_keys = []
+            for future in as_completed(futures):
+                image_key = futures[future]
+                try:
+                    future.result()
+                except Exception as exc:
+                    _locked_echo(
+                        "    ERROR: image build raised exception for %s: %s"
+                        % (image_key, exc)
                     )
-                pull_tag, env_path = result
-                self.__class__._prebuilt_images[image_key] = pull_tag
+                    image_results[image_key] = None
+                if image_results[image_key] is None:
+                    failed_keys.append(image_key)
 
-            self.__class__._prebuilt_env_paths[env_key] = env_path
-            self.__class__._prebuilt_env_paths[_step_state_key(step.name)] = env_path
+        if failed_keys:
+            raise MetaflowException(
+                "Prebuilt image build failed for %d image(s). "
+                "--environment=prebuilt does not fall back to standard conda."
+                % len(failed_keys)
+            )
 
-            pull_tag = self.__class__._prebuilt_images[image_key]
+        # --- Phase 4: Update class state and rewrite step decorators
+        #     (sequential — decorator mutation is not thread-safe). ---
+        for spec in step_specs:
+            image_key = spec["image_key"]
+            result = image_results[image_key]
+            # Should never be None here — failures raised above.
+            if result is None:
+                raise MetaflowException(
+                    "Prebuilt image build failed for step %r. "
+                    "--environment=prebuilt does not fall back to "
+                    "standard conda." % spec["step"].name
+                )
+            pull_tag, env_path = result
+
+            self.__class__._prebuilt_images[image_key] = pull_tag
+            self.__class__._prebuilt_env_paths[spec["env_key"]] = env_path
+            self.__class__._prebuilt_env_paths[
+                _step_state_key(spec["step"].name)
+            ] = env_path
+
             pull_config = registry.pull_config(pull_tag)
-
             found_remote_deco = False
-            for deco in step.decorators:
+            for deco in spec["step"].decorators:
                 if deco.name in CONDA_REMOTE_COMMANDS:
                     prev = deco.attributes.get("image")
                     deco.attributes["image"] = pull_tag
@@ -510,14 +603,15 @@ class PrebuiltCondaEnvironment(CondaEnvironment):
                         deco.attributes[k] = v
                     echo(
                         "    @%s image rewritten for step %s: %r -> %r"
-                        % (deco.name, step.name, prev, pull_tag)
+                        % (deco.name, spec["step"].name, prev, pull_tag)
                     )
                     found_remote_deco = True
 
             if not found_remote_deco:
                 raise MetaflowException(
                     "Prebuilt image was built (%s) but no remote compute "
-                    "decorator found on step %r to rewrite." % (pull_tag, step.name)
+                    "decorator found on step %r to rewrite."
+                    % (pull_tag, spec["step"].name)
                 )
 
         self.__class__._persist_prebuilt_state()
@@ -531,6 +625,7 @@ class PrebuiltCondaEnvironment(CondaEnvironment):
         base_image: str,
         variant: str,
         named_alias: Optional[str] = None,
+        code_package_blob: Optional[bytes] = None,
     ) -> Optional[Tuple[str, str]]:
         """Build the prebuilt image and return ``(pull_tag, env_path)`` or
         ``None`` on failure. ``base_image`` and ``variant`` are resolved by the
@@ -576,11 +671,12 @@ class PrebuiltCondaEnvironment(CondaEnvironment):
             echo("    Reusing existing prebuilt image: %s" % push_tag)
             return pull_tag, env_path
 
-        try:
-            code_package_blob = _build_metaflow_code_package(self, echo)
-        except Exception as e:
-            echo("    ERROR: failed to build metaflow code package: %s" % e)
-            return None
+        if code_package_blob is None:
+            try:
+                code_package_blob = _build_metaflow_code_package(self, echo)
+            except Exception as e:
+                echo("    ERROR: failed to build metaflow code package: %s" % e)
+                return None
 
         # Derive deferred sdists DIRECTLY from this image's resolved env: a pypi
         # package that is a source dist (url_format != ".whl"), web-downloadable,

--- a/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_conda_environment.py
+++ b/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_conda_environment.py
@@ -112,6 +112,7 @@ _DEFERRED_BUILDS_CONTAINER_PATH = "/app/deferred_builds.json"
 _DEFERRED_WHEELS_CONTEXT_DIR = "deferred_wheels"
 _DEFERRED_WHEELS_CONTAINER_DIR = "/app/deferred_wheels"
 _PREBUILT_REGISTRY_CACHE_ENV = "METAFLOW_PREBUILT_REGISTRY_CACHE"
+_DEFAULT_PREBUILT_BUILD_WORKERS = 8
 
 
 def _env_flag_enabled(name: str, default: bool) -> bool:
@@ -119,6 +120,20 @@ def _env_flag_enabled(name: str, default: bool) -> bool:
     if value is None:
         return default
     return value.strip().lower() not in ("", "0", "false", "no", "off")
+
+
+def _prebuilt_build_worker_count(unique_image_count: int) -> int:
+    configured_workers = os.environ.get("METAFLOW_PREBUILT_BUILD_WORKERS")
+    default_workers = min(unique_image_count, _DEFAULT_PREBUILT_BUILD_WORKERS)
+    if configured_workers is None:
+        return default_workers
+    try:
+        workers = int(configured_workers)
+    except ValueError:
+        return default_workers
+    if workers <= 0:
+        return default_workers
+    return workers
 
 
 def _env_path_for(env_id: EnvID) -> str:
@@ -588,20 +603,9 @@ class PrebuiltCondaEnvironment(CondaEnvironment):
             image_results[image_key] = result
 
         # METAFLOW_PREBUILT_BUILD_WORKERS caps concurrent image builds.
-        # Default: unbounded (one worker per unique image) so all independent
-        # step images build in parallel. The builds themselves run remotely via
-        # `newt build-docker --remote`, so local resource pressure is minimal.
-        configured_workers = os.environ.get("METAFLOW_PREBUILT_BUILD_WORKERS")
-        try:
-            max_workers = (
-                int(configured_workers)
-                if configured_workers is not None
-                else len(unique_specs)
-            )
-        except ValueError:
-            max_workers = len(unique_specs)
-        if max_workers <= 0:
-            max_workers = len(unique_specs)
+        # Default to a bounded fanout: enough to parallelize common multi-env
+        # flows without letting a very large flow launch unbounded remote builds.
+        max_workers = _prebuilt_build_worker_count(len(unique_specs))
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             futures = {
                 executor.submit(_build_one, ik, spec): ik

--- a/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_conda_environment.py
+++ b/metaflow-prebuilt/metaflow_extensions/prebuilt/plugins/conda/prebuilt_conda_environment.py
@@ -701,12 +701,6 @@ class PrebuiltCondaEnvironment(CondaEnvironment):
                 % (env_id.req_id[:8], env_id.full_id[:8])
             )
 
-        resolved_env = cast(Conda, self.conda).environment(env_id)
-        if resolved_env is None:
-            echo("    WARNING: Could not find resolved environment for %s" % (env_id,))
-            return None
-
-        env_type = resolved_env.env_type
         env_path = (
             _env_path_for_named(named_alias)
             if named_alias is not None
@@ -730,6 +724,13 @@ class PrebuiltCondaEnvironment(CondaEnvironment):
                 "    Registry prebuilt image reuse disabled by %s; rebuilding: %s"
                 % (_PREBUILT_REGISTRY_CACHE_ENV, push_tag)
             )
+
+        resolved_env = cast(Conda, self.conda).environment(env_id)
+        if resolved_env is None:
+            echo("    WARNING: Could not find resolved environment for %s" % (env_id,))
+            return None
+
+        env_type = resolved_env.env_type
 
         if code_package_blob is None:
             try:

--- a/metaflow-prebuilt/tests/unit/test_generate_dockerfile.py
+++ b/metaflow-prebuilt/tests/unit/test_generate_dockerfile.py
@@ -155,8 +155,17 @@ def test_generate_dockerfile_can_mount_deferred_inputs_with_buildkit():
     assert (
         "RUN --mount=type=bind,source=deferred_builds.json,target=/app/deferred_builds.json,readonly "
         "--mount=type=bind,source=deferred_wheels,target=/app/deferred_wheels,readonly "
+        "BOOTSTRAP=$(mktemp -d) && "
+        "(python -c 'import requests' >/dev/null 2>&1 || "
+        "(python -m pip --version >/dev/null 2>&1 || "
+        "python -m ensurepip --upgrade) && "
+        "python -m pip install --disable-pip-version-check --no-cache-dir "
+        "--index-url https://pypi.netflix.net/simple --target \"$BOOTSTRAP\" "
+        "requests) && METAFLOW_PREBUILT_BUILD_CONTAINER=1 "
+        "PYTHONPATH=\"$BOOTSTRAP:$PYTHONPATH\" "
         "python -m metaflow_extensions.prebuilt.plugins.conda.prebuilt_build_install"
-        " abc123 def456 && rm -rf /opt/metaflow/conda-root/pkgs" in dockerfile
+        " abc123 def456 && rm -rf \"$BOOTSTRAP\" && "
+        "rm -rf /opt/metaflow/conda-root/pkgs" in dockerfile
     )
 
 

--- a/metaflow-prebuilt/tests/unit/test_generate_dockerfile.py
+++ b/metaflow-prebuilt/tests/unit/test_generate_dockerfile.py
@@ -1,5 +1,7 @@
 """Unit tests for _generate_dockerfile()."""
 
+import os
+import subprocess
 from unittest.mock import MagicMock
 
 import pytest
@@ -33,6 +35,15 @@ def _make_resolved_env(env_type="conda"):
     env = MagicMock()
     env.env_type = env_type
     return env
+
+
+def _bootstrap_shell_command(dockerfile):
+    install_run = next(
+        line for line in dockerfile.splitlines() if "prebuilt_build_install" in line
+    )
+    assert install_run.startswith("RUN ")
+    cleanup_marker = " && rm -rf %s/pkgs" % PREBUILT_MAMBA_ROOT_PREFIX
+    return install_run[len("RUN ") :].split(cleanup_marker, 1)[0]
 
 
 def test_generate_dockerfile_regular_has_required_instructions():
@@ -157,10 +168,10 @@ def test_generate_dockerfile_can_mount_deferred_inputs_with_buildkit():
         "--mount=type=bind,source=deferred_wheels,target=/app/deferred_wheels,readonly "
         "BOOTSTRAP=$(mktemp -d) && "
         "(python -c 'import requests' >/dev/null 2>&1 || "
-        "(python -m pip --version >/dev/null 2>&1 || "
+        "((python -m pip --version >/dev/null 2>&1 || "
         "python -m ensurepip --upgrade) && "
         "python -m pip install --disable-pip-version-check --no-cache-dir "
-        '--target "$BOOTSTRAP" requests) && METAFLOW_PREBUILT_BUILD_CONTAINER=1 '
+        '--target "$BOOTSTRAP" requests)) && METAFLOW_PREBUILT_BUILD_CONTAINER=1 '
         'PYTHONPATH="$BOOTSTRAP:$PYTHONPATH" '
         "python -m metaflow_extensions.prebuilt.plugins.conda.prebuilt_build_install"
         ' abc123 def456 && rm -rf "$BOOTSTRAP" && '
@@ -192,6 +203,74 @@ def test_generate_dockerfile_can_configure_bootstrap_pip_options():
         "--index-url https://pypi.example/simple "
         '--target "$BOOTSTRAP" requests'
     ) in dockerfile
+    assert "|| ((python -m pip --version" in dockerfile
+    assert "requests)) && METAFLOW_PREBUILT_BUILD_CONTAINER=1" in dockerfile
+
+
+def test_generate_dockerfile_skips_requests_install_when_import_succeeds(tmp_path):
+    env_id = _make_env_id()
+    resolved_env = _make_resolved_env()
+
+    dockerfile, _ = _generate_dockerfile(
+        "ubuntu:22.04", _env_path_for(env_id), env_id, "conda", resolved_env
+    )
+    command = _bootstrap_shell_command(dockerfile)
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    pip_marker = tmp_path / "pip_was_called"
+    build_install_marker = tmp_path / "build_install_was_called"
+    python_calls = tmp_path / "python_calls"
+    fake_python = fake_bin / "python"
+    fake_python.write_text(
+        """#!/bin/sh
+printf '%s\\n' "$*" >> "$PYTHON_CALLS"
+if [ "$1" = "-c" ] && [ "$2" = "import requests" ]; then
+    exit 0
+fi
+if [ "$1" = "-m" ] && [ "$2" = "pip" ]; then
+    echo pip >> "$PIP_MARKER"
+    exit 42
+fi
+if [ "$1" = "-m" ] && [ "$2" = "ensurepip" ]; then
+    echo ensurepip >> "$PIP_MARKER"
+    exit 42
+fi
+if [ "$1" = "-m" ]; then
+    case "$2" in
+        *.prebuilt_build_install)
+            echo build-install >> "$BUILD_INSTALL_MARKER"
+            exit 0
+            ;;
+    esac
+fi
+echo "unexpected python args: $*" >&2
+exit 2
+"""
+    )
+    fake_python.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": "%s%s%s" % (fake_bin, os.pathsep, env.get("PATH", "")),
+            "PIP_MARKER": str(pip_marker),
+            "BUILD_INSTALL_MARKER": str(build_install_marker),
+            "PYTHON_CALLS": str(python_calls),
+        }
+    )
+
+    result = subprocess.run(
+        ["sh", "-c", command],
+        cwd=str(tmp_path),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not pip_marker.exists(), python_calls.read_text()
+    assert build_install_marker.read_text() == "build-install\n"
 
 
 def test_generate_dockerfile_named_alias_adds_symlink():

--- a/metaflow-prebuilt/tests/unit/test_generate_dockerfile.py
+++ b/metaflow-prebuilt/tests/unit/test_generate_dockerfile.py
@@ -160,11 +160,11 @@ def test_generate_dockerfile_can_mount_deferred_inputs_with_buildkit():
         "(python -m pip --version >/dev/null 2>&1 || "
         "python -m ensurepip --upgrade) && "
         "python -m pip install --disable-pip-version-check --no-cache-dir "
-        "--index-url https://pypi.netflix.net/simple --target \"$BOOTSTRAP\" "
+        '--index-url https://pypi.netflix.net/simple --target "$BOOTSTRAP" '
         "requests) && METAFLOW_PREBUILT_BUILD_CONTAINER=1 "
-        "PYTHONPATH=\"$BOOTSTRAP:$PYTHONPATH\" "
+        'PYTHONPATH="$BOOTSTRAP:$PYTHONPATH" '
         "python -m metaflow_extensions.prebuilt.plugins.conda.prebuilt_build_install"
-        " abc123 def456 && rm -rf \"$BOOTSTRAP\" && "
+        ' abc123 def456 && rm -rf "$BOOTSTRAP" && '
         "rm -rf /opt/metaflow/conda-root/pkgs" in dockerfile
     )
 

--- a/metaflow-prebuilt/tests/unit/test_generate_dockerfile.py
+++ b/metaflow-prebuilt/tests/unit/test_generate_dockerfile.py
@@ -160,13 +160,38 @@ def test_generate_dockerfile_can_mount_deferred_inputs_with_buildkit():
         "(python -m pip --version >/dev/null 2>&1 || "
         "python -m ensurepip --upgrade) && "
         "python -m pip install --disable-pip-version-check --no-cache-dir "
-        '--index-url https://pypi.netflix.net/simple --target "$BOOTSTRAP" '
-        "requests) && METAFLOW_PREBUILT_BUILD_CONTAINER=1 "
+        '--target "$BOOTSTRAP" requests) && METAFLOW_PREBUILT_BUILD_CONTAINER=1 '
         'PYTHONPATH="$BOOTSTRAP:$PYTHONPATH" '
         "python -m metaflow_extensions.prebuilt.plugins.conda.prebuilt_build_install"
         ' abc123 def456 && rm -rf "$BOOTSTRAP" && '
         "rm -rf /opt/metaflow/conda-root/pkgs" in dockerfile
     )
+    assert "pypi.netflix.net" not in dockerfile
+
+
+def test_generate_dockerfile_can_configure_bootstrap_pip_options():
+    env_id = _make_env_id()
+    resolved_env = _make_resolved_env()
+
+    dockerfile, _ = _generate_dockerfile(
+        "ubuntu:22.04",
+        _env_path_for(env_id),
+        env_id,
+        "conda",
+        resolved_env,
+        dockerfile_build_options=DockerfileBuildOptions(
+            bootstrap_pip_install_options=(
+                "--index-url",
+                "https://pypi.example/simple",
+            )
+        ),
+    )
+
+    assert (
+        "python -m pip install --disable-pip-version-check --no-cache-dir "
+        "--index-url https://pypi.example/simple "
+        '--target "$BOOTSTRAP" requests'
+    ) in dockerfile
 
 
 def test_generate_dockerfile_named_alias_adds_symlink():

--- a/metaflow-prebuilt/tests/unit/test_generate_dockerfile.py
+++ b/metaflow-prebuilt/tests/unit/test_generate_dockerfile.py
@@ -52,11 +52,15 @@ def test_generate_dockerfile_regular_has_required_instructions():
     assert "ENV CONDA_ENVS_DIRS=%s" % PREBUILT_ENVS_DIR in dockerfile
     assert "COPY job.tar" in dockerfile
     assert "prebuilt_build_install" in dockerfile
-    assert (
-        "RUN rm -rf %s/pkgs %s/conda-bld /root/.cache/pip"
-        % (PREBUILT_MAMBA_ROOT_PREFIX, PREBUILT_MAMBA_ROOT_PREFIX)
-        in dockerfile
+    cleanup = "rm -rf %s/pkgs %s/conda-bld /root/.cache/pip" % (
+        PREBUILT_MAMBA_ROOT_PREFIX,
+        PREBUILT_MAMBA_ROOT_PREFIX,
     )
+    install_run = next(
+        line for line in dockerfile.splitlines() if "prebuilt_build_install" in line
+    )
+    assert " && %s" % cleanup in install_run
+    assert "RUN %s" % cleanup not in dockerfile
     assert env_id.req_id in dockerfile
     assert env_id.full_id in dockerfile
     assert ".metaflowenv" in dockerfile
@@ -71,6 +75,21 @@ def test_generate_dockerfile_regular_has_required_instructions():
         "wheels": [],
     }
     assert "COPY %s" % _DEFERRED_BUILDS_CONTEXT_NAME in dockerfile
+
+
+def test_generate_dockerfile_installs_env_before_runtime_code_package():
+    env_id = _make_env_id()
+    resolved_env = _make_resolved_env()
+
+    dockerfile, _ = _generate_dockerfile(
+        "ubuntu:22.04", _env_path_for(env_id), env_id, "conda", resolved_env
+    )
+
+    install_support_pos = dockerfile.index("COPY install_support.tar.gz")
+    build_install_pos = dockerfile.index("prebuilt_build_install")
+    runtime_code_pos = dockerfile.index("COPY job.tar")
+
+    assert install_support_pos < build_install_pos < runtime_code_pos
 
 
 def test_generate_dockerfile_deferred_handoff_and_wheels():
@@ -137,7 +156,7 @@ def test_generate_dockerfile_can_mount_deferred_inputs_with_buildkit():
         "RUN --mount=type=bind,source=deferred_builds.json,target=/app/deferred_builds.json,readonly "
         "--mount=type=bind,source=deferred_wheels,target=/app/deferred_wheels,readonly "
         "python -m metaflow_extensions.prebuilt.plugins.conda.prebuilt_build_install"
-        in dockerfile
+        " abc123 def456 && rm -rf /opt/metaflow/conda-root/pkgs" in dockerfile
     )
 
 

--- a/metaflow-prebuilt/tests/unit/test_prebuilt_conda_environment.py
+++ b/metaflow-prebuilt/tests/unit/test_prebuilt_conda_environment.py
@@ -1,7 +1,9 @@
 """Unit tests for PrebuiltCondaEnvironment state file machinery and bootstrap_commands."""
 
+import io
 import json
 import os
+import tarfile
 import tempfile
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -18,6 +20,8 @@ from metaflow_extensions.prebuilt.plugins.conda.prebuilt_conda_environment impor
     _image_variant,
     _image_dedup_key,
     _tag_with_variant,
+    _PREBUILT_REGISTRY_CACHE_ENV,
+    _split_code_package_for_prebuilt_build,
 )
 
 
@@ -54,6 +58,23 @@ def _make_env_id(req="abc", full="def"):
     env_id.full_id = full
     env_id.arch = "linux-64"
     return env_id
+
+
+def _make_code_package_blob():
+    package_blob = io.BytesIO()
+    with tarfile.open(fileobj=package_blob, mode="w:gz") as tar:
+        for name, payload in {
+            ".mf_install": b"marker",
+            ".mf_meta/condav2-1.cnd": b"manifest",
+            ".mf_code/metaflow/__init__.py": b"",
+            ".mf_code/metaflow_extensions/prebuilt/__init__.py": b"",
+            "flow.py": b"flow",
+        }.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            info.mtime = 0
+            tar.addfile(info, io.BytesIO(payload))
+    return package_blob.getvalue()
 
 
 class TestStateFilePersistLoad:
@@ -439,6 +460,280 @@ def test_get_or_build_image_reuses_existing_immutable_tag(monkeypatch):
     build_service.build_and_push.assert_not_called()
 
 
+def test_get_or_build_image_can_bypass_registry_cache(monkeypatch):
+    env_id = _make_env_id()
+    env = PrebuiltCondaEnvironment.__new__(PrebuiltCondaEnvironment)
+    env.conda = MagicMock()
+    env.conda.environment.return_value = SimpleNamespace(env_type="conda", packages=[])
+
+    registry = MagicMock()
+    registry.push_tag.return_value = "registry.example/prebuilt:v30-abc_def"
+    registry.pull_tag.return_value = "prebuilt:v30-abc_def"
+    registry.image_exists.return_value = True
+    registry.push_credentials.return_value = {}
+
+    build_service = MagicMock()
+    build_service.dockerfile_build_options.return_value = (
+        prebuilt_conda_environment.DockerfileBuildOptions()
+    )
+    build_service.build_and_push.return_value = True
+
+    monkeypatch.setenv(_PREBUILT_REGISTRY_CACHE_ENV, "0")
+    monkeypatch.setattr(
+        prebuilt_conda_environment,
+        "_build_metaflow_code_package",
+        MagicMock(return_value=_make_code_package_blob()),
+    )
+    monkeypatch.setattr(
+        prebuilt_conda_environment.DockerBuildService,
+        "from_config",
+        MagicMock(return_value=build_service),
+    )
+
+    result = env._get_or_build_image(
+        env_id,
+        SimpleNamespace(name="start"),
+        lambda *args, **kwargs: None,
+        registry,
+        base_image="cpu-base",
+        variant="linux-64-1234",
+    )
+
+    assert result == (
+        "prebuilt:v30-abc_def-linux-64-1234",
+        "/opt/metaflow/conda-root/envs/metaflow_%s_%s"
+        % (env_id.req_id, env_id.full_id),
+    )
+    registry.image_exists.assert_not_called()
+    build_service.build_and_push.assert_called_once()
+
+
+def test_split_code_package_for_prebuilt_build_separates_runtime_code():
+    src = io.BytesIO()
+    files = {
+        ".mf_install": b"marker",
+        ".mf_meta/condav2-1.cnd": b"manifest",
+        ".mf_code/metaflow/__init__.py": b"",
+        ".mf_code/metaflow_extensions/prebuilt/__init__.py": b"",
+        ".mf_code/user_module.py": b"user",
+        "flow.py": b"flow",
+    }
+    with tarfile.open(fileobj=src, mode="w:gz") as tar:
+        for name, payload in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            info.mtime = 0
+            tar.addfile(info, io.BytesIO(payload))
+
+    support, runtime = _split_code_package_for_prebuilt_build(src.getvalue())
+    support_again, runtime_again = _split_code_package_for_prebuilt_build(
+        src.getvalue()
+    )
+
+    assert support == support_again
+    assert runtime == runtime_again
+
+    def _names(blob):
+        with tarfile.open(fileobj=io.BytesIO(blob), mode="r:gz") as tar:
+            return sorted(tar.getnames())
+
+    assert _names(support) == [
+        ".mf_code/metaflow/__init__.py",
+        ".mf_code/metaflow_extensions/prebuilt/__init__.py",
+        ".mf_install",
+        ".mf_meta/condav2-1.cnd",
+    ]
+    assert _names(runtime) == [".mf_code/user_module.py", "flow.py"]
+
+
+def test_build_prebuilt_images_skips_code_package_when_all_images_exist(
+    tmp_path, monkeypatch
+):
+    ids = {
+        "start": _make_env_id("req1", "full1"),
+        "join": _make_env_id("req2", "full2"),
+    }
+    steps = [
+        SimpleNamespace(
+            name=name,
+            decorators=[SimpleNamespace(name="titus", attributes={"image": "base"})],
+        )
+        for name in ids
+    ]
+
+    env = PrebuiltCondaEnvironment.__new__(PrebuiltCondaEnvironment)
+    env._flow = steps
+    env.conda = MagicMock()
+    env.conda.environment.side_effect = lambda env_id: SimpleNamespace(
+        env_type="conda", packages=[]
+    )
+    env.get_env_id = MagicMock(side_effect=lambda _conda, name: ids[name])
+
+    registry = MagicMock()
+    registry.base_image_identity.side_effect = lambda base, _arch: base
+    registry.push_tag.side_effect = (
+        lambda env_id: "registry.example/prebuilt:v30-%s_%s"
+        % (env_id.req_id, env_id.full_id)
+    )
+    registry.pull_tag.side_effect = lambda env_id: "prebuilt:v30-%s_%s" % (
+        env_id.req_id,
+        env_id.full_id,
+    )
+    registry.image_exists.return_value = True
+    registry.pull_config.return_value = {}
+
+    build_service = MagicMock()
+    monkeypatch.setenv("METAFLOW_TEMPDIR", str(tmp_path))
+    monkeypatch.setenv("METAFLOW_PREBUILT_BASE_IMAGE", "cpu-base")
+    monkeypatch.setenv("METAFLOW_PREBUILT_BUILD_WORKERS", "1")
+    monkeypatch.setattr(prebuilt_conda_environment, "CONDA_REMOTE_COMMANDS", {"titus"})
+    monkeypatch.setattr(
+        prebuilt_conda_environment,
+        "_build_metaflow_code_package",
+        MagicMock(side_effect=AssertionError("should not package code")),
+    )
+    monkeypatch.setattr(
+        prebuilt_conda_environment.DockerBuildService,
+        "from_config",
+        MagicMock(return_value=build_service),
+    )
+
+    with patch.object(
+        prebuilt_conda_environment.ImageRegistry,
+        "from_config",
+        return_value=registry,
+    ):
+        env._build_prebuilt_images(lambda *args, **kwargs: None)
+
+    build_service.build_and_push.assert_not_called()
+    assert registry.image_exists.call_count == 2
+    assert all(
+        step.decorators[0].attributes["image"].startswith("prebuilt:v30-")
+        for step in steps
+    )
+
+
+def test_build_prebuilt_images_includes_build_service_identity_in_tag(
+    tmp_path, monkeypatch
+):
+    env_id = _make_env_id("req1", "full1")
+    step = SimpleNamespace(
+        name="start",
+        decorators=[SimpleNamespace(name="titus", attributes={"image": "base"})],
+    )
+
+    env = PrebuiltCondaEnvironment.__new__(PrebuiltCondaEnvironment)
+    env._flow = [step]
+    env.conda = MagicMock()
+    env.conda.environment.return_value = SimpleNamespace(env_type="conda", packages=[])
+    env.get_env_id = MagicMock(return_value=env_id)
+
+    registry = MagicMock()
+    registry.base_image_identity.side_effect = lambda base, _arch: base
+    registry.push_tag.return_value = "registry.example/prebuilt:v31-req1_full1"
+    registry.pull_tag.return_value = "prebuilt:v31-req1_full1"
+    registry.image_exists.return_value = True
+    registry.pull_config.return_value = {}
+
+    build_service = MagicMock()
+    build_service.image_identity_suffix.return_value = "newt-zstd"
+
+    monkeypatch.setenv("METAFLOW_TEMPDIR", str(tmp_path))
+    monkeypatch.setenv("METAFLOW_PREBUILT_BASE_IMAGE", "cpu-base")
+    monkeypatch.setattr(prebuilt_conda_environment, "CONDA_REMOTE_COMMANDS", {"titus"})
+    monkeypatch.setattr(
+        prebuilt_conda_environment,
+        "_build_metaflow_code_package",
+        MagicMock(side_effect=AssertionError("should not package code")),
+    )
+    monkeypatch.setattr(
+        prebuilt_conda_environment.DockerBuildService,
+        "from_config",
+        MagicMock(return_value=build_service),
+    )
+
+    with patch.object(
+        prebuilt_conda_environment.ImageRegistry,
+        "from_config",
+        return_value=registry,
+    ):
+        env._build_prebuilt_images(lambda *args, **kwargs: None)
+
+    probed_tag = registry.image_exists.call_args.args[0]
+    assert "-newt-zstd-" in probed_tag
+    assert "-newt-zstd-" in step.decorators[0].attributes["image"]
+
+
+def test_build_prebuilt_images_builds_code_package_once_for_multiple_misses(
+    tmp_path, monkeypatch
+):
+    ids = {
+        "start": _make_env_id("req1", "full1"),
+        "join": _make_env_id("req2", "full2"),
+    }
+    steps = [
+        SimpleNamespace(
+            name=name,
+            decorators=[SimpleNamespace(name="titus", attributes={"image": "base"})],
+        )
+        for name in ids
+    ]
+
+    env = PrebuiltCondaEnvironment.__new__(PrebuiltCondaEnvironment)
+    env._flow = steps
+    env.conda = MagicMock()
+    env.conda.environment.side_effect = lambda env_id: SimpleNamespace(
+        env_type="conda", packages=[]
+    )
+    env.get_env_id = MagicMock(side_effect=lambda _conda, name: ids[name])
+
+    registry = MagicMock()
+    registry.base_image_identity.side_effect = lambda base, _arch: base
+    registry.push_tag.side_effect = (
+        lambda env_id: "registry.example/prebuilt:v30-%s_%s"
+        % (env_id.req_id, env_id.full_id)
+    )
+    registry.pull_tag.side_effect = lambda env_id: "prebuilt:v30-%s_%s" % (
+        env_id.req_id,
+        env_id.full_id,
+    )
+    registry.image_exists.return_value = False
+    registry.pull_config.return_value = {}
+    registry.push_credentials.return_value = {}
+
+    build_service = MagicMock()
+    build_service.dockerfile_build_options.return_value = (
+        prebuilt_conda_environment.DockerfileBuildOptions()
+    )
+    build_service.build_and_push.return_value = True
+    package_mock = MagicMock(return_value=_make_code_package_blob())
+
+    monkeypatch.setenv("METAFLOW_TEMPDIR", str(tmp_path))
+    monkeypatch.setenv("METAFLOW_PREBUILT_BASE_IMAGE", "cpu-base")
+    monkeypatch.setenv("METAFLOW_PREBUILT_BUILD_WORKERS", "2")
+    monkeypatch.setattr(prebuilt_conda_environment, "CONDA_REMOTE_COMMANDS", {"titus"})
+    monkeypatch.setattr(
+        prebuilt_conda_environment,
+        "_build_metaflow_code_package",
+        package_mock,
+    )
+    monkeypatch.setattr(
+        prebuilt_conda_environment.DockerBuildService,
+        "from_config",
+        MagicMock(return_value=build_service),
+    )
+
+    with patch.object(
+        prebuilt_conda_environment.ImageRegistry,
+        "from_config",
+        return_value=registry,
+    ):
+        env._build_prebuilt_images(lambda *args, **kwargs: None)
+
+    package_mock.assert_called_once()
+    assert build_service.build_and_push.call_count == 2
+
+
 def test_gather_embedded_wheels_prefers_cached_wheel_over_local_sdist():
     """Codex r13 regression: a source-format package that carries a competing
     local sdist AND has a cached built wheel must embed the WHEEL — not be
@@ -532,6 +827,14 @@ class TestImageIdentity:
     def test_variant_differs_by_arch(self):
         base = "registry.example/big_data:stable"
         assert _image_variant(base, "linux-64") != _image_variant(base, "linux-aarch64")
+
+    def test_variant_differs_by_build_identity(self):
+        base = "registry.example/big_data:stable"
+        arch = "linux-64"
+        default = _image_variant(base, arch)
+        zstd = _image_variant(base, arch, "newt-zstd")
+        assert default != zstd
+        assert "-newt-zstd-" in zstd
 
     def test_variant_is_stable(self):
         assert _image_variant("b:1", "linux-64") == _image_variant("b:1", "linux-64")

--- a/metaflow-prebuilt/tests/unit/test_prebuilt_conda_environment.py
+++ b/metaflow-prebuilt/tests/unit/test_prebuilt_conda_environment.py
@@ -457,6 +457,7 @@ def test_get_or_build_image_reuses_existing_immutable_tag(monkeypatch):
     registry.image_exists.assert_called_once_with(
         "registry.example/prebuilt:v29-abc_def-linux-64-1234"
     )
+    env.conda.environment.assert_not_called()
     build_service.build_and_push.assert_not_called()
 
 

--- a/metaflow-prebuilt/tests/unit/test_prebuilt_conda_environment.py
+++ b/metaflow-prebuilt/tests/unit/test_prebuilt_conda_environment.py
@@ -668,7 +668,7 @@ def test_build_prebuilt_images_includes_build_service_identity_in_tag(
     registry.pull_config.return_value = {}
 
     build_service = MagicMock()
-    build_service.image_identity_suffix.return_value = "newt-zstd"
+    build_service.image_identity_suffix.return_value = "builder-zstd"
 
     monkeypatch.setenv("METAFLOW_TEMPDIR", str(tmp_path))
     monkeypatch.setenv("METAFLOW_PREBUILT_BASE_IMAGE", "cpu-base")
@@ -692,8 +692,8 @@ def test_build_prebuilt_images_includes_build_service_identity_in_tag(
         env._build_prebuilt_images(lambda *args, **kwargs: None)
 
     probed_tag = registry.image_exists.call_args.args[0]
-    assert "-newt-zstd-" in probed_tag
-    assert "-newt-zstd-" in step.decorators[0].attributes["image"]
+    assert "-builder-zstd-" in probed_tag
+    assert "-builder-zstd-" in step.decorators[0].attributes["image"]
 
 
 def test_build_prebuilt_images_builds_code_package_once_for_multiple_misses(
@@ -879,9 +879,9 @@ class TestImageIdentity:
         base = "registry.example/big_data:stable"
         arch = "linux-64"
         default = _image_variant(base, arch)
-        zstd = _image_variant(base, arch, "newt-zstd")
+        zstd = _image_variant(base, arch, "builder-zstd")
         assert default != zstd
-        assert "-newt-zstd-" in zstd
+        assert "-builder-zstd-" in zstd
 
     def test_variant_is_stable(self):
         assert _image_variant("b:1", "linux-64") == _image_variant("b:1", "linux-64")

--- a/metaflow-prebuilt/tests/unit/test_prebuilt_conda_environment.py
+++ b/metaflow-prebuilt/tests/unit/test_prebuilt_conda_environment.py
@@ -509,7 +509,6 @@ def test_get_or_build_image_can_bypass_registry_cache(monkeypatch):
 
 
 def test_split_code_package_for_prebuilt_build_separates_runtime_code():
-    src = io.BytesIO()
     files = {
         ".mf_install": b"marker",
         ".mf_meta/condav2-1.cnd": b"manifest",
@@ -518,16 +517,24 @@ def test_split_code_package_for_prebuilt_build_separates_runtime_code():
         ".mf_code/user_module.py": b"user",
         "flow.py": b"flow",
     }
-    with tarfile.open(fileobj=src, mode="w:gz") as tar:
-        for name, payload in files.items():
-            info = tarfile.TarInfo(name)
-            info.size = len(payload)
-            info.mtime = 0
-            tar.addfile(info, io.BytesIO(payload))
 
-    support, runtime = _split_code_package_for_prebuilt_build(src.getvalue())
+    def _package_blob(metadata_offset=0):
+        src = io.BytesIO()
+        with tarfile.open(fileobj=src, mode="w:gz") as tar:
+            for name, payload in files.items():
+                info = tarfile.TarInfo(name)
+                info.size = len(payload)
+                info.mtime = metadata_offset
+                info.uid = metadata_offset
+                info.gid = metadata_offset
+                info.uname = "user%d" % metadata_offset
+                info.gname = "group%d" % metadata_offset
+                tar.addfile(info, io.BytesIO(payload))
+        return src.getvalue()
+
+    support, runtime = _split_code_package_for_prebuilt_build(_package_blob())
     support_again, runtime_again = _split_code_package_for_prebuilt_build(
-        src.getvalue()
+        _package_blob(metadata_offset=123)
     )
 
     assert support == support_again
@@ -544,6 +551,29 @@ def test_split_code_package_for_prebuilt_build_separates_runtime_code():
         ".mf_meta/condav2-1.cnd",
     ]
     assert _names(runtime) == [".mf_code/user_module.py", "flow.py"]
+
+
+def test_split_code_package_for_prebuilt_build_preserves_file_modes():
+    files = {
+        ".mf_install": b"marker",
+        ".mf_meta/condav2-1.cnd": b"manifest",
+        ".mf_code/metaflow/__init__.py": b"",
+        ".mf_code/metaflow_extensions/prebuilt/__init__.py": b"",
+        "flow.py": b"flow",
+    }
+    src = io.BytesIO()
+    with tarfile.open(fileobj=src, mode="w:gz") as tar:
+        for name, payload in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            info.mtime = 0
+            if name == "flow.py":
+                info.mode = 0o755
+            tar.addfile(info, io.BytesIO(payload))
+
+    _, runtime = _split_code_package_for_prebuilt_build(src.getvalue())
+    with tarfile.open(fileobj=io.BytesIO(runtime), mode="r:gz") as tar:
+        assert tar.getmember("flow.py").mode == 0o755
 
 
 def test_build_prebuilt_images_skips_code_package_when_all_images_exist(
@@ -630,8 +660,8 @@ def test_build_prebuilt_images_includes_build_service_identity_in_tag(
 
     registry = MagicMock()
     registry.base_image_identity.side_effect = lambda base, _arch: base
-    registry.push_tag.return_value = "registry.example/prebuilt:v31-req1_full1"
-    registry.pull_tag.return_value = "prebuilt:v31-req1_full1"
+    registry.push_tag.return_value = "registry.example/prebuilt:v32-req1_full1"
+    registry.pull_tag.return_value = "prebuilt:v32-req1_full1"
     registry.image_exists.return_value = True
     registry.pull_config.return_value = {}
 

--- a/metaflow-prebuilt/tests/unit/test_prebuilt_conda_environment.py
+++ b/metaflow-prebuilt/tests/unit/test_prebuilt_conda_environment.py
@@ -21,6 +21,7 @@ from metaflow_extensions.prebuilt.plugins.conda.prebuilt_conda_environment impor
     _image_dedup_key,
     _tag_with_variant,
     _PREBUILT_REGISTRY_CACHE_ENV,
+    _prebuilt_build_worker_count,
     _split_code_package_for_prebuilt_build,
 )
 
@@ -763,6 +764,21 @@ def test_build_prebuilt_images_builds_code_package_once_for_multiple_misses(
 
     package_mock.assert_called_once()
     assert build_service.build_and_push.call_count == 2
+
+
+def test_prebuilt_build_worker_count_caps_default_but_honors_override(monkeypatch):
+    monkeypatch.delenv("METAFLOW_PREBUILT_BUILD_WORKERS", raising=False)
+    assert _prebuilt_build_worker_count(2) == 2
+    assert _prebuilt_build_worker_count(20) == 8
+
+    monkeypatch.setenv("METAFLOW_PREBUILT_BUILD_WORKERS", "12")
+    assert _prebuilt_build_worker_count(20) == 12
+
+    monkeypatch.setenv("METAFLOW_PREBUILT_BUILD_WORKERS", "not-an-int")
+    assert _prebuilt_build_worker_count(20) == 8
+
+    monkeypatch.setenv("METAFLOW_PREBUILT_BUILD_WORKERS", "0")
+    assert _prebuilt_build_worker_count(20) == 8
 
 
 def test_gather_embedded_wheels_prefers_cached_wheel_over_local_sdist():

--- a/metaflow-prebuilt/tests/unit/test_prebuilt_conda_environment.py
+++ b/metaflow-prebuilt/tests/unit/test_prebuilt_conda_environment.py
@@ -376,6 +376,10 @@ class TestBootstrapCommands:
             PrebuiltCondaEnvironment,
             "_get_or_build_image",
             return_value=("pull-tag", env_path),
+        ), patch.object(
+            prebuilt_conda_environment,
+            "_build_metaflow_code_package",
+            return_value=b"fake-tarball",
         ):
             env._build_prebuilt_images(lambda *args, **kwargs: None)
 

--- a/metaflow-prebuilt/tests/unit/test_prebuilt_conda_environment.py
+++ b/metaflow-prebuilt/tests/unit/test_prebuilt_conda_environment.py
@@ -22,7 +22,7 @@ from metaflow_extensions.prebuilt.plugins.conda.prebuilt_conda_environment impor
     _tag_with_variant,
     _PREBUILT_REGISTRY_CACHE_ENV,
     _prebuilt_build_worker_count,
-    _split_code_package_for_prebuilt_build,
+    _build_install_support_package,
 )
 
 
@@ -510,7 +510,7 @@ def test_get_or_build_image_can_bypass_registry_cache(monkeypatch):
     build_service.build_and_push.assert_called_once()
 
 
-def test_split_code_package_for_prebuilt_build_separates_runtime_code():
+def test_build_install_support_package_extracts_stable_support_subset():
     files = {
         ".mf_install": b"marker",
         ".mf_meta/condav2-1.cnd": b"manifest",
@@ -534,13 +534,10 @@ def test_split_code_package_for_prebuilt_build_separates_runtime_code():
                 tar.addfile(info, io.BytesIO(payload))
         return src.getvalue()
 
-    support, runtime = _split_code_package_for_prebuilt_build(_package_blob())
-    support_again, runtime_again = _split_code_package_for_prebuilt_build(
-        _package_blob(metadata_offset=123)
-    )
+    support = _build_install_support_package(_package_blob())
+    support_again = _build_install_support_package(_package_blob(metadata_offset=123))
 
     assert support == support_again
-    assert runtime == runtime_again
 
     def _names(blob):
         with tarfile.open(fileobj=io.BytesIO(blob), mode="r:gz") as tar:
@@ -552,10 +549,9 @@ def test_split_code_package_for_prebuilt_build_separates_runtime_code():
         ".mf_install",
         ".mf_meta/condav2-1.cnd",
     ]
-    assert _names(runtime) == [".mf_code/user_module.py", "flow.py"]
 
 
-def test_split_code_package_for_prebuilt_build_preserves_file_modes():
+def test_get_or_build_image_keeps_runtime_code_package_unchanged(monkeypatch):
     files = {
         ".mf_install": b"marker",
         ".mf_meta/condav2-1.cnd": b"manifest",
@@ -563,18 +559,57 @@ def test_split_code_package_for_prebuilt_build_preserves_file_modes():
         ".mf_code/metaflow_extensions/prebuilt/__init__.py": b"",
         "flow.py": b"flow",
     }
+
     src = io.BytesIO()
     with tarfile.open(fileobj=src, mode="w:gz") as tar:
         for name, payload in files.items():
             info = tarfile.TarInfo(name)
             info.size = len(payload)
-            info.mtime = 0
             if name == "flow.py":
                 info.mode = 0o755
             tar.addfile(info, io.BytesIO(payload))
+    code_package_blob = src.getvalue()
 
-    _, runtime = _split_code_package_for_prebuilt_build(src.getvalue())
-    with tarfile.open(fileobj=io.BytesIO(runtime), mode="r:gz") as tar:
+    env_id = _make_env_id("req1", "full1")
+    env = PrebuiltCondaEnvironment.__new__(PrebuiltCondaEnvironment)
+    env._flow = [SimpleNamespace(name="start", decorators=[])]
+    env.conda = MagicMock()
+    env.conda.environment.return_value = SimpleNamespace(env_type="conda", packages=[])
+
+    captured = {}
+    build_service = MagicMock()
+    build_service.dockerfile_build_options.return_value = None
+
+    def capture_build(_dockerfile, context_files, *_args, **_kwargs):
+        captured.update(context_files)
+        return True
+
+    build_service.build_and_push.side_effect = capture_build
+    registry = MagicMock()
+    registry.push_credentials.return_value = {}
+    registry.push_tag.return_value = "registry.example/prebuilt:v32-req1_full1"
+    registry.pull_tag.return_value = "prebuilt:v32-req1_full1"
+    registry.image_exists.return_value = False
+
+    monkeypatch.setattr(
+        prebuilt_conda_environment.DockerBuildService,
+        "from_config",
+        MagicMock(return_value=build_service),
+    )
+
+    result = env._get_or_build_image(
+        env_id,
+        "start",
+        lambda *args, **kwargs: None,
+        registry,
+        base_image="cpu-base",
+        variant="linux-64-1234",
+        code_package_blob=code_package_blob,
+    )
+
+    assert result is not None
+    assert captured["job.tar"] == code_package_blob
+    with tarfile.open(fileobj=io.BytesIO(captured["job.tar"]), mode="r:gz") as tar:
         assert tar.getmember("flow.py").mode == 0o755
 
 

--- a/metaflow-prebuilt/tests/unit/test_prebuilt_passb.py
+++ b/metaflow-prebuilt/tests/unit/test_prebuilt_passb.py
@@ -34,12 +34,29 @@ def test_minimal_metaflow_config_uses_core_null_sidecars(monkeypatch):
         with open(os.path.join(config_home, "config.json"), encoding="utf-8") as f:
             config = json.load(f)
     finally:
-        shutil.rmtree(config_home, ignore_errors=True)
+        pbi._cleanup_minimal_metaflow_config()
 
     assert config["METAFLOW_DEFAULT_EVENT_LOGGER"] == "nullSidecarLogger"
     assert config["METAFLOW_DEFAULT_MONITOR"] == "nullSidecarMonitor"
     assert config["METAFLOW_ENABLED_LOGGING_SIDECAR"] == ["nullSidecarLogger"]
     assert config["METAFLOW_ENABLED_MONITOR_SIDECAR"] == ["nullSidecarMonitor"]
+
+
+def test_main_cleans_minimal_metaflow_config_before_fast_exit(monkeypatch, capsys):
+    monkeypatch.setenv("METAFLOW_PREBUILT_BUILD_CONTAINER", "1")
+    monkeypatch.delenv("METAFLOW_PREBUILT_MINIMAL_PLUGIN_CONFIG", raising=False)
+
+    pbi._install_minimal_metaflow_config()
+    config_home = os.environ["METAFLOW_HOME"]
+    assert os.path.isdir(config_home)
+
+    monkeypatch.setattr(pbi, "install_env", lambda req_id, full_id: "/env/path")
+
+    assert pbi.main(["prebuilt_build_install", "req", "full"]) == 0
+
+    assert capsys.readouterr().out.strip() == "/env/path"
+    assert not os.path.exists(config_home)
+    assert os.environ.get("METAFLOW_HOME") != config_home
 
 
 # --------------------------------------------------------------------------

--- a/metaflow-prebuilt/tests/unit/test_prebuilt_passb.py
+++ b/metaflow-prebuilt/tests/unit/test_prebuilt_passb.py
@@ -12,6 +12,8 @@ exercise Pass B + the overlay is a controlled unit test like this one.
 
 import os
 import re
+import json
+import shutil
 import subprocess
 import sys
 import textwrap
@@ -20,6 +22,24 @@ import types
 import pytest
 
 from metaflow_extensions.prebuilt.plugins.conda import prebuilt_build_install as pbi
+
+
+def test_minimal_metaflow_config_uses_core_null_sidecars(monkeypatch):
+    monkeypatch.setenv("METAFLOW_PREBUILT_BUILD_CONTAINER", "1")
+    monkeypatch.delenv("METAFLOW_PREBUILT_MINIMAL_PLUGIN_CONFIG", raising=False)
+
+    pbi._install_minimal_metaflow_config()
+    config_home = os.environ["METAFLOW_HOME"]
+    try:
+        with open(os.path.join(config_home, "config.json"), encoding="utf-8") as f:
+            config = json.load(f)
+    finally:
+        shutil.rmtree(config_home, ignore_errors=True)
+
+    assert config["METAFLOW_DEFAULT_EVENT_LOGGER"] == "nullSidecarLogger"
+    assert config["METAFLOW_DEFAULT_MONITOR"] == "nullSidecarMonitor"
+    assert config["METAFLOW_ENABLED_LOGGING_SIDECAR"] == ["nullSidecarLogger"]
+    assert config["METAFLOW_ENABLED_MONITOR_SIDECAR"] == ["nullSidecarMonitor"]
 
 
 # --------------------------------------------------------------------------

--- a/metaflow-prebuilt/tests/unit/test_prebuilt_passb.py
+++ b/metaflow-prebuilt/tests/unit/test_prebuilt_passb.py
@@ -42,6 +42,51 @@ def test_minimal_metaflow_config_uses_core_null_sidecars(monkeypatch):
     assert config["METAFLOW_ENABLED_MONITOR_SIDECAR"] == ["nullSidecarMonitor"]
 
 
+def test_minimal_metaflow_config_derives_categories_from_metaflow_source(
+    tmp_path, monkeypatch
+):
+    plugins_dir = tmp_path / "metaflow" / "extension_support"
+    plugins_dir.mkdir(parents=True)
+    (tmp_path / "metaflow" / "__init__.py").write_text("")
+    (plugins_dir / "__init__.py").write_text("")
+    (plugins_dir / "plugins.py").write_text(
+        "_plugin_categories = {\n"
+        "    'step_decorator': None,\n"
+        "    'environment': None,\n"
+        "    'datastore': None,\n"
+        "    'logging_sidecar': None,\n"
+        "    'monitor_sidecar': None,\n"
+        "    'new_plugin_category': None,\n"
+        "}\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    config = pbi._minimal_metaflow_config()
+    enabled_categories = {
+        key.removeprefix("METAFLOW_ENABLED_")
+        for key in config
+        if key.startswith("METAFLOW_ENABLED_")
+    }
+
+    assert enabled_categories == {
+        "STEP_DECORATOR",
+        "ENVIRONMENT",
+        "DATASTORE",
+        "LOGGING_SIDECAR",
+        "MONITOR_SIDECAR",
+        "NEW_PLUGIN_CATEGORY",
+    }
+    assert set(pbi._MINIMAL_PLUGIN_ALLOWLIST).issubset(enabled_categories)
+    assert config["METAFLOW_DEFAULT_EVENT_LOGGER"] == "nullSidecarLogger"
+    assert config["METAFLOW_DEFAULT_MONITOR"] == "nullSidecarMonitor"
+    assert config["METAFLOW_ENABLED_ENVIRONMENT"] == ["nflx", "conda"]
+    assert config["METAFLOW_ENABLED_DATASTORE"] == ["local"]
+    assert config["METAFLOW_ENABLED_LOGGING_SIDECAR"] == ["nullSidecarLogger"]
+    assert config["METAFLOW_ENABLED_MONITOR_SIDECAR"] == ["nullSidecarMonitor"]
+    assert config["METAFLOW_ENABLED_STEP_DECORATOR"] == []
+    assert config["METAFLOW_ENABLED_NEW_PLUGIN_CATEGORY"] == []
+
+
 def test_main_cleans_minimal_metaflow_config_before_fast_exit(monkeypatch, capsys):
     monkeypatch.setenv("METAFLOW_PREBUILT_BUILD_CONTAINER", "1")
     monkeypatch.delenv("METAFLOW_PREBUILT_MINIMAL_PLUGIN_CONFIG", raising=False)

--- a/metaflow-prebuilt/tests/unit/test_prebuilt_passb.py
+++ b/metaflow-prebuilt/tests/unit/test_prebuilt_passb.py
@@ -87,6 +87,49 @@ def test_minimal_metaflow_config_derives_categories_from_metaflow_source(
     assert config["METAFLOW_ENABLED_NEW_PLUGIN_CATEGORY"] == []
 
 
+def test_install_minimal_metaflow_config_replaces_previous_home(monkeypatch):
+    monkeypatch.setenv("METAFLOW_PREBUILT_BUILD_CONTAINER", "1")
+    monkeypatch.delenv("METAFLOW_PREBUILT_MINIMAL_PLUGIN_CONFIG", raising=False)
+
+    pbi._install_minimal_metaflow_config()
+    first_home = os.environ["METAFLOW_HOME"]
+    assert os.path.isdir(first_home)
+    try:
+        pbi._install_minimal_metaflow_config()
+        second_home = os.environ["METAFLOW_HOME"]
+
+        assert second_home != first_home
+        assert not os.path.exists(first_home)
+        assert os.path.isdir(second_home)
+    finally:
+        pbi._cleanup_minimal_metaflow_config()
+
+
+def test_install_minimal_metaflow_config_does_not_publish_partial_home(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("METAFLOW_PREBUILT_BUILD_CONTAINER", "1")
+    monkeypatch.delenv("METAFLOW_PREBUILT_MINIMAL_PLUGIN_CONFIG", raising=False)
+    monkeypatch.setenv("METAFLOW_HOME", "original-home")
+    config_home = tmp_path / "partial-config"
+
+    def fake_mkdtemp(prefix):
+        config_home.mkdir()
+        return str(config_home)
+
+    def fail_config():
+        raise RuntimeError("failed before config write")
+
+    monkeypatch.setattr(pbi.tempfile, "mkdtemp", fake_mkdtemp)
+    monkeypatch.setattr(pbi, "_minimal_metaflow_config", fail_config)
+
+    with pytest.raises(RuntimeError, match="failed before config write"):
+        pbi._install_minimal_metaflow_config()
+
+    assert os.environ["METAFLOW_HOME"] == "original-home"
+    assert not config_home.exists()
+
+
 def test_main_cleans_minimal_metaflow_config_before_fast_exit(monkeypatch, capsys):
     monkeypatch.setenv("METAFLOW_PREBUILT_BUILD_CONTAINER", "1")
     monkeypatch.delenv("METAFLOW_PREBUILT_MINIMAL_PLUGIN_CONFIG", raising=False)


### PR DESCRIPTION
## Summary

- **Root cause**: `_build_prebuilt_images()` used a plain `for step in self._flow` loop — each Docker image built and pushed before the next started. A flow with 7 distinct step envs (e.g. artwork_flow with GPU steps) ran ~33 min sequentially when all 7 images could build concurrently.
- **Fix**: Restructure into 4 phases — collect specs (sequential), build MetaflowPackage once (saves rebuilding the same tarball N times), build unique images concurrently via `ThreadPoolExecutor`, rewrite decorators (sequential).
- **Expected speedup**: `artwork_flow` 33 min → ~10 min (bounded by the slowest single step: ~9.9 min GPU env).

## Changes

- `_build_prebuilt_images()`: split into 4 phases with `ThreadPoolExecutor` for the build phase
- `_get_or_build_image()`: accepts optional `code_package_blob` (pre-built by Phase 2, avoiding N redundant builds)
- New env var `METAFLOW_PREBUILT_BUILD_WORKERS` to cap concurrency (default: one worker per unique image since `newt build-docker --remote` runs remotely)
- Thread-safe echo via lock; decorator rewriting kept sequential

## Test plan

- [ ] Single-step flow: no regression — `ThreadPoolExecutor(max_workers=1)` with one task behaves identically to serial
- [ ] Multi-env flow: confirm all steps get distinct images and decorators are rewritten correctly
- [ ] Dedup: two steps sharing the same env + base only trigger one `newt build` call
- [ ] Named env: named-alias steps rebuild on every deploy (existing behavior preserved)
- [ ] `METAFLOW_PREBUILT_BUILD_WORKERS=1` cap: serializes back to one-at-a-time for environments with limited CI capacity

🤖 Generated with [Claude Code](https://claude.com/claude-code)