### PR TITLE
Fix implicit Conda Python patch range

### DIFF
--- a/metaflow-netflixext/metaflow_extensions/netflixext/plugins/conda/utils.py
+++ b/metaflow-netflixext/metaflow_extensions/netflixext/plugins/conda/utils.py
@@ -973,10 +973,12 @@ version_maps = {
 
 
 def sanitize_python_version(v: str) -> str:
-    # Use major.minor version only to avoid OS-specific patch version constraints
+    # Avoid pinning the launcher's OS-specific patch build, while preserving
+    # Conda's range semantics. "python==3.10" is an exact 3.10.0 match;
+    # "python==3.10.*" selects a compatible 3.10 patch release.
     mapped_version = version_maps.get(v, v)
     version_parts = mapped_version.split(".")
-    return f"{version_parts[0]}.{version_parts[1]}"
+    return f"{version_parts[0]}.{version_parts[1]}.*"
 
 
 # Function heavily inspired from https://github.com/hauntsaninja/change_wheel_version

--- a/tests/plugins/conda/utils_test.py
+++ b/tests/plugins/conda/utils_test.py
@@ -1,6 +1,12 @@
 from itertools import chain
+
+# Import Metaflow first so its extension plugin registry is initialized before
+# importing plugin modules directly.
+import metaflow
 from metaflow_extensions.netflixext.plugins.conda.utils import (
+    dict_to_strlist,
     filter_packages_by_markers,
+    sanitize_python_version,
 )
 from metaflow_extensions.netflixext.plugins.conda.resolvers.pylock_toml_resolver import (
     PylockTomlResolver,
@@ -9,8 +15,28 @@ from metaflow_extensions.netflixext.plugins.conda.resolvers.pylock_toml_resolver
 import pytest
 import tomli
 from io import BytesIO
+from metaflow._vendor.packaging.utils import canonicalize_version
 from metaflow._vendor.packaging.version import InvalidVersion
 from contextlib import nullcontext as does_not_raise
+
+
+@pytest.mark.parametrize(
+    ("launcher_version", "conda_version", "conda_requirement"),
+    [
+        ("3.10.20", "3.10.*", "python==3.10.*"),
+        ("3.11.14", "3.11.*", "python==3.11.*"),
+        ("3.12.12", "3.12.*", "python==3.12.*"),
+    ],
+)
+def test_sanitize_python_version_preserves_patch_range_semantics(
+    launcher_version, conda_version, conda_requirement
+):
+    sanitized = sanitize_python_version(launcher_version)
+
+    assert sanitized == conda_version
+    assert dict_to_strlist({"python": canonicalize_version(sanitized)}) == [
+        conda_requirement
+    ]
 
 
 def test_filter_packages_by_marker():


### PR DESCRIPTION
## Summary

When a step does not specify `python=`, the Conda environment derives Python from the launcher. `sanitize_python_version()` currently truncates a launcher version such as `3.10.20` to `3.10` to avoid an OS-specific patch pin.

The resulting dependency is serialized as:

```text
python==3.10
```

Micromamba treats that as an exact normalized match for Python 3.10.0, not as a compatible 3.10 patch range. This change emits `3.10.*` instead, producing:

```text
python==3.10.*
```

Explicit user pins such as `@conda(python="3.10.12")` remain exact and are unaffected.

## Root cause

A direct micromamba dry-run confirms the different semantics:

```text
python==3.10   -> python-3.10.0-h543edf9_3_cpython
python==3.10.* -> python-3.10.20-h267e890_1_cpython
```

This surfaced in a PyMC/PyTensor flow after migration to `metaflow-netflixext==1.3.15`:

- The earlier environment requested `conda::python==3.10.20`, resolved Python 3.10.20, and included `libxcrypt`.
- The failing environment requested `conda::python==3.10`, resolved Python 3.10.0, and did not include `libxcrypt`.
- That old Python 3.10.0 package's `Python.h` includes `<crypt.h>` but its package metadata does not depend on `libxcrypt`, causing PyTensor JIT compilation to fail.

The downstream missing-header error is therefore a symptom of selecting Python 3.10.0 accidentally. Adding `libxcrypt` in user code is not the platform-level correction.

## Change

- Preserve major/minor compatibility using the Conda wildcard form: `major.minor.*`.
- Add regression coverage for Python 3.10, 3.11, and 3.12.
- Verify the downstream serialized dependency remains `python==major.minor.*`.

## Verification

```text
46 focused utility/resolver tests passed
176 non-environment-dependent Conda plugin tests passed
Black 24.4.2 check passed
git diff --check passed
```

A full local Conda plugin run reached 213 passing tests. The remaining 18 failures are existing environment-dependent CLI/parser integration tests whose micromamba `info` channel assumptions do not match this workstation.
